### PR TITLE
Fix link issue on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ It should be the best Obsidian plugin for synchronizing Todoist tasks so far.
 
 ## Installation
 
-1. Download the latest release of the plugin from the [Releases](https://github.com/HeroBlackInk/ultimate-todoist-sync/releases) page.
+1. Download the latest release of the plugin from the [Releases](https://github.com/HeroBlackInk/ultimate-todoist-sync-for-obsidian/releases) page.
 2. Extract the downloaded zip file and copy the entire folder to your Obsidian plugins directory.
 3. Enable the plugin in the Obsidian settings.
 


### PR DESCRIPTION
Replace:
https://github.com/HeroBlackInk/ultimate-todoist-sync/releases with:
https://github.com/HeroBlackInk/ultimate-todoist-sync-for-obsidian/releases