### PR TITLE
Suggested README changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+## CHANGELOG
+### prelease [1.0.38] - 2023-06-09
+
+https://github.com/HeroBlackInk/ultimate-todoist-sync-for-obsidian/releases/tag/v1.0.38-beta
+
+- New feature
+    - 1.0.38 beta now supports date formats for tasks.
+    - Todoist task link is added.
+
+### prelease [1.0.37] - 2023-06-05
+
+https://github.com/HeroBlackInk/ultimate-todoist-sync-for-obsidian/releases/tag/v1.0.37-beta
+
+- New feature
+    - Two-way automatic synchronization, no longer need to manually click the sync button.
+    - Full vault sync option, automatically adding `#todoist` to all tasks.
+    - Notes/comments one-way synchronization from Todoist to Obsidian.
+- Bug fix
+    - Fixed the bug of time zone conversion.
+    - Removed the "#" from the Todoist label.
+    - Update the obsidian link in Todoist after moving or renaming a file.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Ultimate Todoist Sync for Obsidian
 
-It should be the best Obsidian plugin for synchronizing Todoist tasks so far.
+The Ultimate Todoist Sync plugin automatically creates tasks in Todoist and synchronizes task state between Obsidian and Todoist.
+
 
 ## Demo
 
@@ -10,10 +11,11 @@ It should be the best Obsidian plugin for synchronizing Todoist tasks so far.
 ### Settings page
 <img src="/attachment/settings.png" width="500">
 
+
 ## Features 
 
 ### 
-|                         | Sync from Obsidian to Todoist | Sync from Todoist to Obsidian | Description |
+| Feature                 | Sync from Obsidian to Todoist | Sync from Todoist to Obsidian | Description |
 |-------------------------|-------------------------------|-------------------------------|-------------|
 | Add task                | ✅                            | 🔜                           |             |
 | Delete task             | ✅                            | 🔜                           |             |
@@ -33,20 +35,38 @@ It should be the best Obsidian plugin for synchronizing Todoist tasks so far.
 | Task notes              | 🔜                            | ✅                           |   Currently, task notes/comments only support one-way synchronization from Todoist to Obsidian.          |
 
 
-
-
-
-
 ## Installation
+
+### From within Obsidian
+
+From Obsidian v1.3.5+, you can activate this plugin within Obsidian by doing the following:
+
+1. Open Obsidian's `Settings` window
+2. Select the `Community plugins` tab on the left
+3. Make sure `Restricted mode` is **off**
+4. Click `Browse` next to `Community Plugins`
+5. Search for and click on `Ultimate Todoist Sync`
+6. Click `Install`
+7. Once installed, close the `Community Plugins` window
+8. Under `Installed Plugins`, activate the `Ultimate Todoist Sync` plugin
+
+You can update the plugin following the same procedure, clicking `Update` instead of `Install`
+
+### Manually
+
+If you would rather install the plugin manually, you can do the following:
 
 1. Download the latest release of the plugin from the [Releases](https://github.com/HeroBlackInk/ultimate-todoist-sync-for-obsidian/releases) page.
 2. Extract the downloaded zip file and copy the entire folder to your Obsidian plugins directory.
 3. Enable the plugin in the Obsidian settings.
 
+
 ## Configuration
 
-1. In the Obsidian settings, click on the "Plugins" tab and then click the gear icon next to the "Ultimate Todoist Sync for Obsidian" plugin.
-2. Enter the Todoist API..
+1. Open Obsidian's `Settings` window
+2. Select the `Community plugins` tab on the left
+3. Under `Installed plugins`, click the gear icon next to the `Ultimate Todoist Sync` plugin
+4. Enter your Todoist API token
 
 
 ## Settings
@@ -57,11 +77,10 @@ New tasks will be added to the default project, and you can change the default p
 3. Full vault sync
 By enabling this option, the plugin will automatically add `#todoist` to all tasks, which will modify all files in the vault.
 
+
 ## Usage
 
-
 ### Task format
-
 
 | Syntax | Description | Example |
 | --- | --- | --- |
@@ -82,7 +101,6 @@ You can see the current file's default project in the status bar at the bottom r
 <img src="/attachment/statusBar.png" width="500">
 
 
-
 ## Disclaimer
 
 This plugin is for learning purposes only. The author makes no representations or warranties of any kind, express or implied, about the accuracy, completeness, or usefulness of this plugin and shall not be liable for any losses or damages resulting from the use of this plugin.
@@ -91,9 +109,11 @@ The author shall not be responsible for any loss or damage, including but not li
 
 By using this plugin, you agree to be bound by all the terms of this disclaimer. If you have any questions, please contact the author.
 
+
 ## Contributing
 
 Contributions are welcome! If you'd like to contribute to the plugin, please read our [contributing guidelines](CONTRIBUTING.md) and submit a pull request.
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,34 +2,6 @@
 
 It should be the best Obsidian plugin for synchronizing Todoist tasks so far.
 
-
-## CHANGELOG
-### prelease [1.0.38] - 2023-06-09
-
-https://github.com/HeroBlackInk/ultimate-todoist-sync-for-obsidian/releases/tag/v1.0.38-beta
-
-- New feature
-    - 1.0.38 beta now supports date formats for tasks.
-    - Todoist task link is added.
-
-
-
-## CHANGELOG
-### prelease [1.0.37] - 2023-06-05
-
-https://github.com/HeroBlackInk/ultimate-todoist-sync-for-obsidian/releases/tag/v1.0.37-beta
-
-- New feature
-    - Two-way automatic synchronization, no longer need to manually click the sync button.
-    - Full vault sync option, automatically adding `#todoist` to all tasks.
-    - Notes/comments one-way synchronization from Todoist to Obsidian.
-- Bug fix
-    - Fixed the bug of time zone conversion.
-    - Removed the "#" from the Todoist label.
-    - Update the obsidian link in Todoist after moving or renaming a file.
-
-
-
 ## Demo
 
 ### Usage
@@ -37,8 +9,6 @@ https://github.com/HeroBlackInk/ultimate-todoist-sync-for-obsidian/releases/tag/
 
 ### Settings page
 <img src="/attachment/settings.png" width="500">
-
-
 
 ## Features 
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ By using this plugin, you agree to be bound by all the terms of this disclaimer.
 
 ## Contributing
 
-Contributions are welcome! If you'd like to contribute to the plugin, please read our [contributing guidelines](CONTRIBUTING.md) and submit a pull request.
+Contributions are welcome! If you'd like to contribute to the plugin, please feel free to submit a pull request.
 
 
 ## License


### PR DESCRIPTION
I've been using your plugin for a few weeks and it's been great!

One mistake I made was pulling the 1.0.37-beta version of the plugin due to the `CHANGELOG` section of `README.md` making it look like that was the latest version rather than installing the plugin from within Obsidian.  Obviously user error on my part, but I thought I'd offer a PR to make `README.md` clearer and ended up making a few more changes 🙃 

What I changed (and thoughts on why):
- `README.md` is shown when searching for community plugins within Obsidian.  I think the user expectation here is more commonly to see how the plugin works rather than what changed recently
- I moved the changelog to its own file as most users aren't going to be looking for what changed.  As well, the changelog hasn't been kept up to date so moving it helps the user not think `1.0.38` is the latest version.  Alternatively, moving the changelog to the bottom of `README.md` would also work
- Added instructions on how to install the plugin from within Obsidian for users who, like me, forgot that's an easy option
- Expanded on the `Configuration` instructions to match the style of the `Installation` instructions
- Changed the wording under `Contributing` since the linked `CONTRIBUTING.md` file doesn't exist
- Whitespace changes for uniformity

No worries if you don't like any of the changes -- just thought I'd make some suggestions 😄 :shipit: 