### PR TITLE
Implement Sync Todoist -> Obsidian

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -489,7 +489,7 @@ export default class UltimateTodoistSyncForObsidian extends Plugin {
 			if (target.checked) {
 				this.todoistSync.closeTask(taskId);
 			} else {
-				this.todoistSync.repoenTask(taskId);
+				this.todoistSync.reopenTask(taskId);
 			}
 		} else {
 			//console.log('未找到 todoist_id');

--- a/src/fileOperation.ts
+++ b/src/fileOperation.ts
@@ -426,7 +426,6 @@ export class FileOperation   {
                     .replace("{{title}}", taskTitle)
                     .replace("{{TITLE}}",taskTitle.toUpperCase())
                 const dateFormat = this.plugin.settings.pullTemplateTaskNotesFormat.match(/\{\{date\|([\[\]\s\w.:-]*)}}/)
-                console.log(dateFormat)
                 if (dateFormat != null && dateFormat.length > 0) {
                     // remove the date format from the given filename
                     tmpFile = tmpFile.replace("|" + dateFormat[1], "")
@@ -439,7 +438,6 @@ export class FileOperation   {
                 if (useThisFolder != "") {
                     tmpFile = useThisFolder + "/" + tmpFile
                 }
-                console.log(`Creating new file from template: ${tmpFile}`)
 
                 try {
                     const file = await this.app.vault.create(tmpFile, template)

--- a/src/fileOperation.ts
+++ b/src/fileOperation.ts
@@ -295,17 +295,31 @@ export class FileOperation   {
         let modified = false
     
         for (let i = 0; i < lines.length; i++) {
-            const line = lines[i]
-            if (line.includes(taskId) && this.plugin.taskParser.hasTodoistTag(line)) {
-                const oldTaskContent = this.plugin.taskParser.getTaskContentFromLineText(line)
-                const newTaskContent = evt.extra_data.content
+			const line = lines[i]
+			if (line.includes(taskId) && this.plugin.taskParser.hasTodoistTag(line)) {
+				const oldTaskContent = this.plugin.taskParser.getTaskContentFromLineText(line)
+				const newTaskContent = evt.extra_data.content
 
-                lines[i] = line.replace(oldTaskContent, newTaskContent)
-                modified = true
-                break
-            }
-        }
-    
+				let newline = line.replace(oldTaskContent, newTaskContent)
+
+				// remove tags if label missing
+				const oldTags = this.plugin.taskParser.getTagsFromLineText(line)
+				const newTags = evt.extra_data.labels
+				const removedTags = oldTags.filter(x => !newTags.includes(x))
+				removedTags.forEach(tag =>
+					newline = newline.replace(` #${tag}`, ' ')
+				)
+
+				// append labels as tags
+				const addTags = newTags.filter(x => !oldTags.includes(x))
+				addTags.forEach(tag => newline += ` #${tag}`)
+
+				lines[i] = newline
+				modified = true
+				break
+			}
+		}
+
         if (modified) {
         const newContent = lines.join('\n')
         //console.log(newContent)

--- a/src/fileOperation.ts
+++ b/src/fileOperation.ts
@@ -470,10 +470,10 @@ export class FileOperation   {
             if (taskObject.due != undefined) {
                 text_with_out_link += ` 📅${taskObject.due.date}`
             }
-            for(let i = 0; i < taskObject.labels.length; i++){
-                text_with_out_link += ` #${taskObject.labels[i]}`
-            }
             text_with_out_link += " #todoist"
+			for(let i = 0; i < taskObject.labels.length; i++){
+				text_with_out_link += ` #${taskObject.labels[i]}`
+			}
 
             const link = `[link](${taskObject.url})`
             let newLine = this.plugin.taskParser.addTodoistLink(text_with_out_link,link)

--- a/src/fileOperation.ts
+++ b/src/fileOperation.ts
@@ -317,18 +317,19 @@ export class FileOperation   {
 
 				let newline = line.replace(oldTaskContent, newTaskContent)
 
-				// remove tags if label missing
 				const oldTags = this.plugin.taskParser.getAllTagsFromLineText(line)
 				const newTags = evt.extra_data.labels
-				const removedTags = oldTags.filter(x => !newTags.includes(x))
-				removedTags.forEach(tag =>
-					newline = newline.replace(` #${tag}`, ' ')
-				)
+				if(oldTags != undefined && newTags != undefined) {
+					// remove tags if label missing
+					const removedTags = oldTags.filter(x => !newTags.includes(x))
+					removedTags.forEach(tag =>
+						newline = newlinereplace(` #${tag} `, ' ')
+					)
 
-				// append labels as tags
-				const addTags = newTags.filter(x => !oldTags.includes(x))
-				addTags.forEach(tag => newline += ` #${tag}`)
-
+					// append labels as tags
+					const addTags = newTags.filter(x => !oldTags.includes(x))
+					addTags.forEach(tag => newline += ` #${tag}`)
+				}
 				lines[i] = newline
 				modified = true
 				break

--- a/src/fileOperation.ts
+++ b/src/fileOperation.ts
@@ -470,6 +470,9 @@ export class FileOperation   {
             if (taskObject.due != undefined) {
                 text_with_out_link += ` 📅${taskObject.due.date}`
             }
+            for(let i = 0; i < taskObject.labels.length; i++){
+                text_with_out_link += ` #${taskObject.labels[i].name}`
+            }
             text_with_out_link += " #todoist"
 
             const link = `[link](${taskObject.url})`

--- a/src/fileOperation.ts
+++ b/src/fileOperation.ts
@@ -317,18 +317,20 @@ export class FileOperation   {
 
 				let newline = line.replace(oldTaskContent, newTaskContent)
 
-				const oldTags = this.plugin.taskParser.getAllTagsFromLineText(line)
-				const newTags = evt.extra_data.labels
-				if(oldTags != undefined && newTags != undefined) {
-					// remove tags if label missing
-					const removedTags = oldTags.filter(x => !newTags.includes(x))
-					removedTags.forEach(tag =>
-						newline = newlinereplace(` #${tag} `, ' ')
-					)
+				if(this.plugin.settings.syncTagsFromTodoist){
+					const oldTags = this.plugin.taskParser.getAllTagsFromLineText(line)
+					const newTags = evt.extra_data.labels
+					if(oldTags != undefined && newTags != undefined) {
+						// remove tags if label missing
+						const removedTags = oldTags.filter(x => !newTags.includes(x))
+						removedTags.forEach(tag =>
+							newline = newlinereplace(` #${tag} `, ' ')
+						)
 
-					// append labels as tags
-					const addTags = newTags.filter(x => !oldTags.includes(x))
-					addTags.forEach(tag => newline += ` #${tag}`)
+						// append labels as tags
+						const addTags = newTags.filter(x => !oldTags.includes(x))
+						addTags.forEach(tag => newline += ` #${tag}`)
+					}
 				}
 				lines[i] = newline
 				modified = true

--- a/src/fileOperation.ts
+++ b/src/fileOperation.ts
@@ -471,7 +471,7 @@ export class FileOperation   {
                 text_with_out_link += ` 📅${taskObject.due.date}`
             }
             for(let i = 0; i < taskObject.labels.length; i++){
-                text_with_out_link += ` #${taskObject.labels[i].name}`
+                text_with_out_link += ` #${taskObject.labels[i]}`
             }
             text_with_out_link += " #todoist"
 

--- a/src/fileOperation.ts
+++ b/src/fileOperation.ts
@@ -1,7 +1,12 @@
 
 import {pullTargetMode, pullTaskNotesMode} from "./settings";
 import moment from "moment";
-import {createDailyNote, getAllDailyNotes, getDailyNote} from "obsidian-daily-notes-interface";
+import {
+    appHasDailyNotesPluginLoaded,
+    createDailyNote,
+    getAllDailyNotes,
+    getDailyNote
+} from "obsidian-daily-notes-interface";
 import UltimateTodoistSyncForObsidian from "../main";
 import {App, Notice, TAbstractFile, TFile} from "obsidian";
 export class FileOperation   {
@@ -375,13 +380,13 @@ export class FileOperation   {
         if (currentTask != undefined) {
             filepath = currentTask.path
         } else if (this.plugin.settings.pullTargetMode == pullTargetMode.DailyNote) {
+            if(!appHasDailyNotesPluginLoaded()){
+                console.log("Daily notes core plugin is not loaded. So we cannot create daily note. Please install daily notes core plugin. Interrupt now.")
+            }
             const date = moment();
-            let file;
-            try {
-                const dailies = getAllDailyNotes()
-                file = getDailyNote(date, dailies)
-            } catch (e) {
-                console.error(`Error getting daily note: ${e}`)
+            const dailies = getAllDailyNotes()
+            let file = getDailyNote(date, dailies)
+            if (file == null) {
                 file = await createDailyNote(date)
             }
             filepath = file.path

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -178,25 +178,21 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
 		);
 		*/
 
-		new Setting(containerEl)
-			.setName('Default Project')
-			.setDesc('New tasks are automatically synced to the default project. You can modify the project here.')
-			.addDropdown(component => 
-				component
-						.addOption(this.plugin.settings.defaultProjectId,this.plugin.settings.defaultProjectName)
-						.addOptions(myProjectsOptions)
-						.onChange((value)=>{
-							this.plugin.settings.defaultProjectId = value
-							this.plugin.settings.defaultProjectName = this.plugin.cacheOperation.getProjectNameByIdFromCache(value)
-							this.plugin.saveSettings()
-							
-							
-						})
-						
-				)
-
+        new Setting(containerEl)
+            .setName('Default Project')
+            .setDesc('New tasks are automatically synced to the default project. You can modify the project here.')
+            .addDropdown(component =>
+                component
                     .addOptions(myProjectsOptions)
                     .setValue(this.plugin.settings.defaultProjectId)
+                    .onChange((value) => {
+                        this.plugin.settings.defaultProjectId = value
+                        this.plugin.settings.defaultProjectName = this.plugin.cacheOperation.getProjectNameByIdFromCache(value)
+                        this.plugin.saveSettings()
+
+
+                    })
+            )
 
 		
 		new Setting(containerEl)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -28,6 +28,7 @@ export interface UltimateTodoistSyncSettings {
 	enableFullVaultSync: boolean;
 	statistics: any;
 	debugMode: boolean;
+	removeTagsWithText: boolean;
 	pullFromProject: string;
 	pullFromProjectId: string;
 	pullTargetMode: pullTargetMode;
@@ -56,6 +57,7 @@ export const DEFAULT_SETTINGS: UltimateTodoistSyncSettings = {
     debugMode: false,
     //mySetting: 'default',
     //todoistTasksFilePath: 'todoistTasks.json'
+	removeTagsWithText: True,
     pullFromProject: "Inbox",
     pullFromProjectId: "",
     pullTargetMode: pullTargetMode.DailyNote,
@@ -407,6 +409,18 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
 						})
 						
 				)
+
+		new Setting(containerEl)
+			.setName('Remove tags with text')
+			.setDesc('If enabled, this opton will remove tags with text from the task description in todoist. Otherwise it only removes the hashtag sign. Very helpful, if you use tags in your text.')
+			.addToggle(component =>
+				component
+					.setValue(this.plugin.settings.removeTagsWithText)
+					.onChange((value) => {
+						this.plugin.settings.removeTagsWithText = value
+						this.plugin.saveSettings()
+					})
+			)
 
 		new Setting(containerEl)
 			.setName('Backup Todoist Data')

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -62,7 +62,7 @@ export const DEFAULT_SETTINGS: UltimateTodoistSyncSettings = {
     pullTemplateUseFolder: "",
     pullTemplateUsePath: "",
     pullTemplateUseForProjects: pullTaskNotesMode.taskNote,
-    pullTemplateTaskNotesFormat: "YYYY-MM-DD",
+    pullTemplateTaskNotesFormat: "{{date|YYYY-MM-DD}}_{{title}}",
     pullDailyNoteAppendMode: true,
     pullDailyNoteInsertAfterText: ""
 }
@@ -512,7 +512,7 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
 						href: "https://momentjs.com/docs/#/displaying/format/",
 						text: "moment.js",
 					}),
-					' is used to format the date.'
+					' is used to format the date. Available variables are: {{date}},{{date|format}},{{title}},{{TITLE}}'
 				)
                 new Setting(containerEl)
                     .setName('Task notes format')

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -58,7 +58,7 @@ export const DEFAULT_SETTINGS: UltimateTodoistSyncSettings = {
     debugMode: false,
     //mySetting: 'default',
     //todoistTasksFilePath: 'todoistTasks.json'
-	removeTagsWithText: True,
+	removeTagsWithText: true,
     pullFromProject: "Inbox",
     pullFromProjectId: "",
     pullTargetMode: pullTargetMode.Template,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -210,9 +210,19 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
 							new Notice("Full vault sync is enabled.")							
 						})
 						
-				)						
+				)
 
-
+		new Setting(containerEl)
+			.setName('Remove tags with text')
+			.setDesc('If enabled, this opton will remove tags with text from the task description in todoist. Otherwise it only removes the hashtag sign. Very helpful, if you use tags in your text.')
+			.addToggle(component =>
+				component
+					.setValue(this.plugin.settings.removeTagsWithText)
+					.onChange((value) => {
+						this.plugin.settings.removeTagsWithText = value
+						this.plugin.saveSettings()
+					})
+			)
 
 		new Setting(containerEl)
 		.setName('Manual Sync')
@@ -411,17 +421,6 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
 						
 				)
 
-		new Setting(containerEl)
-			.setName('Remove tags with text')
-			.setDesc('If enabled, this opton will remove tags with text from the task description in todoist. Otherwise it only removes the hashtag sign. Very helpful, if you use tags in your text.')
-			.addToggle(component =>
-				component
-					.setValue(this.plugin.settings.removeTagsWithText)
-					.onChange((value) => {
-						this.plugin.settings.removeTagsWithText = value
-						this.plugin.saveSettings()
-					})
-			)
 
 		new Setting(containerEl)
 			.setName('Backup Todoist Data')

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -30,6 +30,7 @@ export interface UltimateTodoistSyncSettings {
 	statistics: any;
 	debugMode: boolean;
 	removeTagsWithText: boolean;
+	syncTagsFromTodoist: boolean;
 	pullFromProject: string;
 	pullFromProjectId: string;
 	pullTargetMode: pullTargetMode;
@@ -59,6 +60,7 @@ export const DEFAULT_SETTINGS: UltimateTodoistSyncSettings = {
     //mySetting: 'default',
     //todoistTasksFilePath: 'todoistTasks.json'
 	removeTagsWithText: true,
+	syncTagsFromTodoist: false,
     pullFromProject: "Inbox",
     pullFromProjectId: "",
     pullTargetMode: pullTargetMode.Template,
@@ -220,6 +222,18 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.removeTagsWithText)
 					.onChange((value) => {
 						this.plugin.settings.removeTagsWithText = value
+						this.plugin.saveSettings()
+					})
+			)
+
+		new Setting(containerEl)
+			.setName('Sync tags from Todoist')
+			.setDesc('BETA: If enabled, this option will sync tags from todoist to obsidian. Otherwise it ignores them as before. Because this can lead to undefined behaviour when the same task was changed in todoist and obsidian, you should not use it if you want to use both tools at the same time.')
+			.addToggle(component =>
+				component
+					.setValue(this.plugin.settings.syncTagsFromTodoist)
+					.onChange((value) => {
+						this.plugin.settings.syncTagsFromTodoist = value
 						this.plugin.saveSettings()
 					})
 			)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -438,9 +438,21 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
                         this.display()
                     })
             })
-        new Setting(containerEl)
+
+        const desc = document.createDocumentFragment();
+		desc.append('If daily Note is selected, all new tasks will be created in a daily note. This needs the ',
+			desc.createEl("a", {
+				href: "https://help.obsidian.md/Plugins/Daily+notes",
+				text: "daily notes core plugin",
+			}),
+			desc.createEl("br"),
+			'In template note, it uses a template to store the tasks.'
+		)
+
+
+		new Setting(containerEl)
             .setName('Select Mode')
-            .setDesc('If daily Note is selected, all new tasks will be created in a daily note. In template note, it uses a template to store the tasks.')
+            .setDesc(desc)
             .addDropdown(component => {
                 component
                     .addOption(pullTargetMode.DailyNote.valueOf(), "Daily note")
@@ -494,9 +506,17 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
                         })
                 })
             if (this.plugin.settings.pullTemplateUseForProjects != pullTaskNotesMode.projectNote) {
+				const desc = document.createDocumentFragment();
+				desc.append('Use the given format to create new notes for tasks. ',
+					desc.createEl("a", {
+						href: "https://momentjs.com/docs/#/displaying/format/",
+						text: "moment.js",
+					}),
+					' is used to format the date.'
+				)
                 new Setting(containerEl)
                     .setName('Task notes format')
-                    .setDesc('Use the given format to create new notes for tasks. <a href="https://momentjs.com/docs/#/displaying/format/" target="_blank">Moment.js</a> is used to format the date.')
+					.setDesc(desc)
                     .addText((text) => {
                         text
                             .setPlaceholder(this.plugin.settings.pullTemplateTaskNotesFormat)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -195,6 +195,8 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
 						
 				)
 
+                    .addOptions(myProjectsOptions)
+                    .setValue(this.plugin.settings.defaultProjectId)
 
 		
 		new Setting(containerEl)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,10 +7,10 @@ interface MyProject {
   }
 
 export enum pullTargetMode {
-    DailyNote="daily", Template="template"
+	DailyNote = "daily", Template = "template"
 }
 
-enum pullTaskNotesMode {
+export enum pullTaskNotesMode {
     projectNote, taskNote
 }
 
@@ -527,34 +527,33 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
                             })
                     })
             }
-        } else {
-            new Setting(containerEl)
-                .setName('Append Mode')
-                .setDesc('Append tasks to daily note at the bottom of the file.')
-                .addToggle(component => {
-                    component
-                        .setValue(this.plugin.settings.pullDailyNoteAppendMode)
-                        .onChange((value) => {
-                            this.plugin.settings.pullDailyNoteAppendMode = value
-                            this.plugin.saveSettings()
-                            this.display()
-                        })
-                })
-            if (!this.plugin.settings.pullDailyNoteAppendMode) {
-                new Setting(containerEl)
-                    .setName('Insert After')
-                    .setDesc('Insert tasks after given text in Daily Note. If not text can be found, it falls back to append mode.')
-                    .addText((text) => {
-                        text
-                            .setPlaceholder('Enter text')
-                            .setValue(this.plugin.settings.pullDailyNoteInsertAfterText)
-                            .onChange(async (value) => {
-                                this.plugin.settings.pullDailyNoteInsertAfterText = value;
-                                this.plugin.saveSettings()
-                            })
-                    })
-            }
         }
+		new Setting(containerEl)
+			.setName('Append Mode')
+			.setDesc('Append tasks at the bottom of the note.')
+			.addToggle(component => {
+				component
+					.setValue(this.plugin.settings.pullDailyNoteAppendMode)
+					.onChange((value) => {
+						this.plugin.settings.pullDailyNoteAppendMode = value
+						this.plugin.saveSettings()
+						this.display()
+					})
+			})
+		if (!this.plugin.settings.pullDailyNoteAppendMode) {
+			new Setting(containerEl)
+				.setName('Insert After')
+				.setDesc('Insert tasks after given text in note. If not text can be found, it falls back to append mode.')
+				.addText((text) => {
+					text
+						.setPlaceholder('Enter text')
+						.setValue(this.plugin.settings.pullDailyNoteInsertAfterText)
+						.onChange(async (value) => {
+							this.plugin.settings.pullDailyNoteInsertAfterText = value;
+							this.plugin.saveSettings()
+						})
+				})
+		}
     }
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,6 @@
 import { App, Notice, Plugin, PluginSettingTab, Setting } from 'obsidian';
 import UltimateTodoistSyncForObsidian from "../main";
+import {appHasDailyNotesPluginLoaded} from "obsidian-daily-notes-interface";
 
 interface MyProject {
 	id: string;
@@ -60,7 +61,7 @@ export const DEFAULT_SETTINGS: UltimateTodoistSyncSettings = {
 	removeTagsWithText: True,
     pullFromProject: "Inbox",
     pullFromProjectId: "",
-    pullTargetMode: pullTargetMode.DailyNote,
+    pullTargetMode: pullTargetMode.Template,
     pullTemplateUseFolder: "",
     pullTemplateUsePath: "",
     pullTemplateUseForProjects: pullTaskNotesMode.taskNote,
@@ -454,7 +455,7 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
             })
 
         const desc = document.createDocumentFragment();
-		desc.append('If daily Note is selected, all new tasks will be created in a daily note. This needs the ',
+		desc.append('If daily Note core plugin is enabled and is selected, all new tasks will be created in a daily note. This needs the ',
 			desc.createEl("a", {
 				href: "https://help.obsidian.md/Plugins/Daily+notes",
 				text: "daily notes core plugin",
@@ -468,8 +469,11 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
             .setName('Select Mode')
             .setDesc(desc)
             .addDropdown(component => {
+				if(appHasDailyNotesPluginLoaded()){
+					component
+						.addOption(pullTargetMode.DailyNote.valueOf(), "Daily note")
+				}
                 component
-                    .addOption(pullTargetMode.DailyNote.valueOf(), "Daily note")
                     .addOption(pullTargetMode.Template.valueOf(), 'Template Note')
                     .setValue(this.plugin.settings.pullTargetMode.valueOf())
                     .onChange((value) => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -61,7 +61,7 @@ export const DEFAULT_SETTINGS: UltimateTodoistSyncSettings = {
     pullTargetMode: pullTargetMode.DailyNote,
     pullTemplateUseFolder: "",
     pullTemplateUsePath: "",
-    pullTemplateUseForProjects: false,
+    pullTemplateUseForProjects: pullTaskNotesMode.taskNote,
     pullTemplateTaskNotesFormat: "YYYY-MM-DD",
     pullDailyNoteAppendMode: true,
     pullDailyNoteInsertAfterText: ""

--- a/src/syncModule.ts
+++ b/src/syncModule.ts
@@ -822,8 +822,6 @@ export class TodoistSync  {
             const unsynchronized_notes_added_events = this.plugin.todoistSyncAPI.filterActivityEvents(result3, { event_type: 'added', object_type: 'note' })
             const unsynchronized_project_events = this.plugin.todoistSyncAPI.filterActivityEvents(result1, { object_type: 'project' })
 
-			// sync updated labels to obsidian
-			const tasks_with_changed_labels = await this.getTasksFromTodoistWithUpdatedLabels()
 
 			console.log("completed tasks",unsynchronized_item_completed_events)
 			console.log("uncompleted tasks",unsynchronized_item_uncompleted_events)
@@ -831,12 +829,18 @@ export class TodoistSync  {
 			console.log("project events",unsynchronized_project_events)
 			console.log("new notes",unsynchronized_notes_added_events)
 			console.log("new tasks",unsynchronized_item_added_events)
-			console.log("generated events with updated labels",tasks_with_changed_labels)
 
 			await this.syncCompletedTaskStatusToObsidian(unsynchronized_item_completed_events)
 			await this.syncUncompletedTaskStatusToObsidian(unsynchronized_item_uncompleted_events)
 			await this.syncUpdatedTaskToObsidian(unsynchronized_item_updated_events)
-			await this.syncUpdatedTaskToObsidian(tasks_with_changed_labels)
+
+			if(this.plugin.settings.syncTagsFromTodoist){
+				// sync updated labels to obsidian
+				const tasks_with_changed_labels = await this.getTasksFromTodoistWithUpdatedLabels()
+				console.log("generated events with updated labels",tasks_with_changed_labels)
+				await this.syncUpdatedTaskToObsidian(tasks_with_changed_labels)
+			}
+
 			await this.syncNewTasksToObsidian(unsynchronized_item_added_events)
 			await this.syncAddedTaskNoteToObsidian(unsynchronized_notes_added_events)
 

--- a/src/syncModule.ts
+++ b/src/syncModule.ts
@@ -833,6 +833,9 @@ export class TodoistSync  {
             await this.syncNewTasksToObsidian(unsynchronized_item_added_events)
             await this.syncAddedTaskNoteToObsidian(unsynchronized_notes_added_events)
 
+			// sync updated labels to obsidian
+			await this.syncUpdatedTaskToObsidian(await this.getTasksFromTodoistWithUpdatedLabels())
+
             if(unsynchronized_project_events.length){
                 console.log('New project event')
                 await this.plugin.cacheOperation.saveProjectsToCache()
@@ -845,6 +848,24 @@ export class TodoistSync  {
         }
 
     }
+
+	async getTasksFromTodoistWithUpdatedLabels(){
+		const all_tasks_in_todoist = await this.plugin.todoistSyncAPI?.getAllTasks()
+		const all_tasks_in_obsidian = await this.plugin.cacheOperation?.loadTasksFromCache()
+		let tasks_with_updated_labels = []
+
+		all_tasks_in_obsidian.forEach((obs_task) => {
+			const todoist_task = all_tasks_in_todoist.find((t) => t.id === obs_task.id)
+			if (todoist_task) {
+				const labelsModified = this.plugin.taskParser?.taskTagCompare(obs_task, todoist_task)
+				if(labelsModified) {
+					tasks_with_updated_labels.push(todoist_task)
+				}
+			}
+		})
+
+		return tasks_with_updated_labels
+	}
 
 
 

--- a/src/syncModule.ts
+++ b/src/syncModule.ts
@@ -806,8 +806,9 @@ export class TodoistSync  {
                 (objA) => savedTasks.some((objB) => objB.id === objA.parent_item_id)
                 )
 
-             const result4 = result1.filter(
-            (objA) => !savedTasks.some((objB) => objB.id === objA.object_id)
+			// usage for new tasks
+            const result4 = result1.filter(
+            	(objA) => !savedTasks.some((objB) => objB.id === objA.object_id)
             )
 
             const unsynchronized_item_completed_events = this.plugin.todoistSyncAPI.filterActivityEvents(result2, { event_type: 'completed', object_type: 'item' })

--- a/src/syncModule.ts
+++ b/src/syncModule.ts
@@ -22,7 +22,7 @@ export class TodoistSync  {
 
 
 
-      
+
     async deletedTaskCheck(file_path:string): Promise<void> {
 
         let file
@@ -46,7 +46,7 @@ export class TodoistSync  {
 
 
         //console.log(filepath)
-      
+
 
         //const frontMatter = await this.plugin.fileOperation.getFrontMatter(file);
         const frontMatter = await this.plugin.cacheOperation.getFileMetadata(filepath)
@@ -54,15 +54,15 @@ export class TodoistSync  {
           console.log('frontmatter没有task')
           return;
         }
-        
 
-        
+
+
 
         //console.log(currentFileValue)
         const currentFileValueWithOutFrontMatter = currentFileValue.replace(/^---[\s\S]*?---\n/, '');
         const frontMatter_todoistTasks = frontMatter.todoistTasks;
         const frontMatter_todoistCount = frontMatter.todoistCount;
-      
+
         const deleteTasksPromises = frontMatter_todoistTasks
           .filter((taskId) => !currentFileValueWithOutFrontMatter.includes(taskId))
           .map(async (taskId) => {
@@ -71,7 +71,7 @@ export class TodoistSync  {
               const api = this.plugin.todoistRestAPI.initializeAPI()
               const response = await api.deleteTask(taskId);
               //console.log(`response is ${response}`);
-      
+
               if (response) {
                 //console.log(`task ${taskId} 删除成功`);
                 new Notice(`task ${taskId} is deleted`)
@@ -383,7 +383,7 @@ export class TodoistSync  {
             let dueDateChanged = false;
             let parentIdChanged = false;
             let priorityChanged = false;
-            
+
             let updatedContent = {}
             if (contentModified) {
                 console.log(`Content modified for task ${lineTask_todoist_id}`)
@@ -396,7 +396,7 @@ export class TodoistSync  {
                 updatedContent.labels = lineTask.labels
                 tagsChanged = true;
             }
-            
+
 
             if (dueDateModified) {
                 console.log(`Due date modified for task ${lineTask_todoist_id}`)
@@ -438,7 +438,7 @@ export class TodoistSync  {
                 const updatedTask = await this.plugin.todoistRestAPI.UpdateTask(lineTask.todoist_id.toString(),updatedContent)
                 updatedTask.path = filepath
                 this.plugin.cacheOperation.updateTaskToCacheByID(updatedTask);
-            } 
+            }
 
             if (statusModified) {
                 console.log(`Status modified for task ${lineTask_todoist_id}`)
@@ -451,19 +451,19 @@ export class TodoistSync  {
                 this.plugin.todoistRestAPI.OpenTask(lineTask.todoist_id.toString());
                 this.plugin.cacheOperation.reopenTaskToCacheByID( lineTask.todoist_id.toString());
                 }
-                
+
                 statusChanged = true;
             }
 
 
-            
+
             if (contentChanged || statusChanged ||dueDateChanged ||tagsChanged || projectChanged || priorityChanged) {
                 console.log(lineTask)
                 console.log(savedTask)
                 //`Task ${lastLineTaskTodoistId} was modified`
                 this.plugin.saveSettings()
                 let message = `Task ${lineTask_todoist_id} is updated.`;
-    
+
                 if (contentChanged) {
                     message += " Content was changed.";
                 }
@@ -482,13 +482,13 @@ export class TodoistSync  {
                 if (priorityChanged) {
                     message += " Priority was changed.";
                 }
-                
+
                 new Notice(message);
 
             } else {
                 //console.log(`Task ${lineTask_todoist_id} did not change`);
             }
-            
+
             } catch (error) {
             console.error('Error updating task:', error);
             }
@@ -504,7 +504,7 @@ export class TodoistSync  {
         let currentFileValue;
         let view;
         let filepath;
-      
+
         try {
           if (file_path) {
             file = this.app.vault.getAbstractFileByPath(file_path);
@@ -516,12 +516,12 @@ export class TodoistSync  {
             filepath = file?.path;
             currentFileValue = view?.data;
           }
-      
+
           const content = currentFileValue;
-      
+
           let hasModifiedTask = false;
           const lines = content.split('\n');
-      
+
           for (let i = 0; i < lines.length; i++) {
             const line = lines[i];
             if (this.plugin.taskParser.hasTodoistId(line) && this.plugin.taskParser.hasTodoistTag(line)) {
@@ -534,7 +534,7 @@ export class TodoistSync  {
               }
             }
           }
-      
+
           if (hasModifiedTask) {
             try {
               // Perform necessary actions on the modified content and front matter
@@ -574,7 +574,7 @@ export class TodoistSync  {
             console.error('Error opening task:', error);
             throw error; // 抛出错误使调用方能够捕获并处理它
         }
-    } 
+    }
 
 
     /**
@@ -610,7 +610,7 @@ export class TodoistSync  {
     await this.plugin.cacheOperation.deleteTaskFromCacheByIDs(deletedTaskIds); // 更新 JSON 文件
     this.plugin.saveSettings()
     //console.log(`共删除了 ${deletedTaskIds.length} 条 task`);
-    
+
 
     return deletedTaskIds;
     }
@@ -645,7 +645,7 @@ export class TodoistSync  {
         this.plugin.saveSettings()
 
 
-        
+
 
 
         } catch (error) {
@@ -681,12 +681,12 @@ export class TodoistSync  {
         console.error('同步任务状态时出错：', error)
         }
     }
-  
+
     // 同步updated item状态到 Obsidian 中
     async  syncUpdatedTaskToObsidian(unSynchronizedEvents) {
-        //console.log(unSynchronizedEvents) 
+        //console.log(unSynchronizedEvents)
         try {
-        
+
         // 处理未同步的事件并等待所有处理完成
         const processedEvents = []
         for (const e of unSynchronizedEvents) {   //如果要修改代码，让completeTaskInTheFile(e.object_id)按照顺序依次执行，可以将Promise.allSettled()方法改为使用for...of循环来处理未同步的事件。具体步骤如下：
@@ -719,7 +719,7 @@ export class TodoistSync  {
         } catch (error) {
         console.error('Error syncing updated item', error)
         }
-        
+
     }
 
     async syncUpdatedTaskContentToObsidian(e){
@@ -758,7 +758,7 @@ export class TodoistSync  {
         }
 
         // 将新事件合并到现有事件中并保存到 JSON
-        
+
         await this.plugin.cacheOperation.appendEventsToCache(processedEvents)
         this.plugin.saveSettings()
         } catch (error) {
@@ -789,27 +789,25 @@ export class TodoistSync  {
     async syncTodoistToObsidian(){
         try{
             const all_activity_events = await this.plugin.todoistSyncAPI.getNonObsidianAllActivityEvents()
-            
+
             // remove synchonized events
             const savedEvents = await this.plugin.cacheOperation.loadEventsFromCache()
             const result1 = all_activity_events.filter(
             (objA) => !savedEvents.some((objB) => objB.id === objA.id)
             )
-    
-           
+
             const savedTasks = await this.plugin.cacheOperation.loadTasksFromCache()
             // 找出 task id 存在于 Obsidian 中的 task activity
             const result2 = result1.filter(
-            (objA) => savedTasks.some((objB) => objB.id === objA.object_id)
+            (objA) => !savedTasks.some((objB) => objB.id === objA.object_id)
             )
             // 找出 task id 存在于 Obsidian 中的 note activity
             const result3 = result1.filter(
-                (objA) => savedTasks.some((objB) => objB.id === objA.parent_item_id)
+                (objA) => !savedTasks.some((objB) => objB.id === objA.parent_item_id)
                 )
-        
-    
-    
-    
+
+            console.log(result1)
+
             const unsynchronized_item_completed_events = this.plugin.todoistSyncAPI.filterActivityEvents(result2, { event_type: 'completed', object_type: 'item' })
             const unsynchronized_item_uncompleted_events = this.plugin.todoistSyncAPI.filterActivityEvents(result2, { event_type: 'uncompleted', object_type: 'item' })
 
@@ -822,20 +820,21 @@ export class TodoistSync  {
             console.log(unsynchronized_item_completed_events)
             console.log(unsynchronized_item_uncompleted_events)
             console.log(unsynchronized_item_updated_events)
-            console.log(unsynchronized_project_events) 
+            console.log(unsynchronized_project_events)
             console.log(unsynchronized_notes_added_events)
-    
+
             await this.syncCompletedTaskStatusToObsidian(unsynchronized_item_completed_events)
             await this.syncUncompletedTaskStatusToObsidian(unsynchronized_item_uncompleted_events)
             await this.syncUpdatedTaskToObsidian(unsynchronized_item_updated_events)
             await this.syncNewTasksToObsidian(unsynchronized_item_added_events)
             await this.syncAddedTaskNoteToObsidian(unsynchronized_notes_added_events)
+
             if(unsynchronized_project_events.length){
                 console.log('New project event')
                 await this.plugin.cacheOperation.saveProjectsToCache()
                 await this.plugin.cacheOperation.appendEventsToCache(unsynchronized_project_events)
             }
-    
+
 
         }catch (err){
             console.error('An error occurred while synchronizing:', err);
@@ -848,10 +847,10 @@ export class TodoistSync  {
     async  backupTodoistAllResources() {
         try {
         const resources = await this.plugin.todoistSyncAPI.getAllResources()
-    
+
         const now: Date = new Date();
         const timeString: string = `${now.getFullYear()}${now.getMonth()+1}${now.getDate()}${now.getHours()}${now.getMinutes()}${now.getSeconds()}`;
-    
+
         const name = "todoist-backup-"+timeString+".json"
 
         this.app.vault.create(name,JSON.stringify(resources))
@@ -890,6 +889,6 @@ export class TodoistSync  {
 
 
 
-    
+
 
 }

--- a/src/syncModule.ts
+++ b/src/syncModule.ts
@@ -789,6 +789,7 @@ export class TodoistSync  {
     async syncTodoistToObsidian(){
         try{
             const all_activity_events = await this.plugin.todoistSyncAPI.getNonObsidianAllActivityEvents()
+            console.log("all activity events", all_activity_events)
 
             // remove synchonized events
             const savedEvents = await this.plugin.cacheOperation.loadEventsFromCache()

--- a/src/syncModule.ts
+++ b/src/syncModule.ts
@@ -563,7 +563,7 @@ export class TodoistSync  {
     }
 
     //open task
-    async repoenTask(taskId:string) : Promise<void>{
+    async reopenTask(taskId:string) : Promise<void>{
         try {
             await this.plugin.todoistRestAPI.OpenTask(taskId)
             await this.plugin.fileOperation.uncompleteTaskInTheFile(taskId)

--- a/src/syncModule.ts
+++ b/src/syncModule.ts
@@ -799,21 +799,23 @@ export class TodoistSync  {
             const savedTasks = await this.plugin.cacheOperation.loadTasksFromCache()
             // 找出 task id 存在于 Obsidian 中的 task activity
             const result2 = result1.filter(
-            (objA) => !savedTasks.some((objB) => objB.id === objA.object_id)
+            (objA) => savedTasks.some((objB) => objB.id === objA.object_id)
             )
             // 找出 task id 存在于 Obsidian 中的 note activity
             const result3 = result1.filter(
-                (objA) => !savedTasks.some((objB) => objB.id === objA.parent_item_id)
+                (objA) => savedTasks.some((objB) => objB.id === objA.parent_item_id)
                 )
 
-            console.log(result1)
+             const result4 = result1.filter(
+            (objA) => !savedTasks.some((objB) => objB.id === objA.object_id)
+            )
 
             const unsynchronized_item_completed_events = this.plugin.todoistSyncAPI.filterActivityEvents(result2, { event_type: 'completed', object_type: 'item' })
             const unsynchronized_item_uncompleted_events = this.plugin.todoistSyncAPI.filterActivityEvents(result2, { event_type: 'uncompleted', object_type: 'item' })
 
             //Items updated (only changes to content, description, due_date and responsible_uid)
             const unsynchronized_item_updated_events = this.plugin.todoistSyncAPI.filterActivityEvents(result2, { event_type: 'updated', object_type: 'item' })
-            const unsynchronized_item_added_events = this.plugin.todoistSyncAPI.filterActivityEvents(result2, { event_type: 'added', object_type: 'item' })
+            const unsynchronized_item_added_events = this.plugin.todoistSyncAPI.filterActivityEvents(result4, { event_type: 'added', object_type: 'item' })
 
             const unsynchronized_notes_added_events = this.plugin.todoistSyncAPI.filterActivityEvents(result3, { event_type: 'added', object_type: 'note' })
             const unsynchronized_project_events = this.plugin.todoistSyncAPI.filterActivityEvents(result1, { object_type: 'project' })

--- a/src/syncModule.ts
+++ b/src/syncModule.ts
@@ -826,6 +826,13 @@ export class TodoistSync  {
             console.log(unsynchronized_item_updated_events)
             console.log(unsynchronized_project_events)
             console.log(unsynchronized_notes_added_events)
+			console.log("completed tasks",unsynchronized_item_completed_events)
+			console.log("uncompleted tasks",unsynchronized_item_uncompleted_events)
+			console.log("updated tasks",unsynchronized_item_updated_events)
+			console.log("project events",unsynchronized_project_events)
+			console.log("new notes",unsynchronized_notes_added_events)
+			console.log("new tasks",unsynchronized_item_added_events)
+			console.log("updated tasks with changed labels", tasks_with_changed_labels_as_event)
 
             await this.syncCompletedTaskStatusToObsidian(unsynchronized_item_completed_events)
             await this.syncUncompletedTaskStatusToObsidian(unsynchronized_item_uncompleted_events)

--- a/src/taskParser.ts
+++ b/src/taskParser.ts
@@ -279,6 +279,7 @@ export class TaskParser   {
         let TaskContent = lineText.replace(REGEX.TASK_CONTENT.REMOVE_INLINE_METADATA,"")
                                     .replace(REGEX.TASK_CONTENT.REMOVE_TODOIST_LINK,"")
                                     .replace(REGEX.TASK_CONTENT.REMOVE_PRIORITY," ") //priority 前后必须都有空格，
+									.replace(" #todoist"," ")
 
 		// remove tags with text only if enabled in settings
 		if (this.plugin.settings.removeTagsWithText) {

--- a/src/taskParser.ts
+++ b/src/taskParser.ts
@@ -276,11 +276,17 @@ export class TaskParser   {
   
   
     getTaskContentFromLineText(lineText:string) {
-        const TaskContent = lineText.replace(REGEX.TASK_CONTENT.REMOVE_INLINE_METADATA,"")
+        let TaskContent = lineText.replace(REGEX.TASK_CONTENT.REMOVE_INLINE_METADATA,"")
                                     .replace(REGEX.TASK_CONTENT.REMOVE_TODOIST_LINK,"")
                                     .replace(REGEX.TASK_CONTENT.REMOVE_PRIORITY," ") //priority 前后必须都有空格，
-                                    .replace(REGEX.TASK_CONTENT.REMOVE_TAGS,"")
-                                    .replace(REGEX.TASK_CONTENT.REMOVE_DATE,"")
+
+		// remove tags with text only if enabled in settings
+		if (this.plugin.settings.removeTagsWithText) {
+			TaskContent = TaskContent.replace(REGEX.TASK_CONTENT.REMOVE_TAGS,"")
+		} else {
+			TaskContent = TaskContent.replace(" #"," ")
+		}
+		TaskContent = TaskContent.replace(REGEX.TASK_CONTENT.REMOVE_DATE,"")
                                     .replace(REGEX.TASK_CONTENT.REMOVE_CHECKBOX,"")
                                     .replace(REGEX.TASK_CONTENT.REMOVE_CHECKBOX_WITH_INDENTATION,"")
                                     .replace(REGEX.TASK_CONTENT.REMOVE_SPACE,"")

--- a/src/todoistSyncAPI.ts
+++ b/src/todoistSyncAPI.ts
@@ -93,6 +93,14 @@ export class TodoistSyncAPI   {
       }
       }
 
+	  async getAllTasks() {
+		// FIXME: This triggers a full sync which is heavy. A different approach for truckload of tasks should be taken
+		  // The other solution could be through webhooks, which is a complete rewrite.
+		const all_resources = await this.getAllResources();
+		const all_tasks = all_resources.items;
+		return all_tasks;
+	  }
+
 
 
       //update user timezone

--- a/src/todoistSyncAPI.ts
+++ b/src/todoistSyncAPI.ts
@@ -169,6 +169,8 @@ export class TodoistSyncAPI   {
         //console.log(filteredArray)
         return(filteredArray)
 			const filteredArray = allActivityEvents.filter((obj: Event) => !obj.extra_data.client?.includes("obsidian") && obj.parent_project_id == this.plugin.settings.pullFromProjectId);
+			const filteredArray = allActivityEvents.filter((obj: Event) => !obj.extra_data.client?.includes("obsidian") && obj.parent_project_id == this.plugin.settings.pullFromProjectId);
+			return (filteredArray)
 
       }catch(err){
         console.error('An error occurred:', err);

--- a/src/todoistSyncAPI.ts
+++ b/src/todoistSyncAPI.ts
@@ -165,12 +165,9 @@ export class TodoistSyncAPI   {
         //console.log(allActivity)
         const allActivityEvents = allActivity.events
         //client中不包含obsidian 的activity
-        const filteredArray = allActivityEvents.filter(obj => !obj.extra_data.client?.includes("obsidian")); 
+        const filteredArray = allActivityEvents.filter(obj => !obj.extra_data.client?.includes("obsidian") && this.plugin.settings.pullFromProjectId.includes(obj.parent_project_id) );
         //console.log(filteredArray)
         return(filteredArray)
-			const filteredArray = allActivityEvents.filter((obj: Event) => !obj.extra_data.client?.includes("obsidian") && obj.parent_project_id == this.plugin.settings.pullFromProjectId);
-			const filteredArray = allActivityEvents.filter((obj: Event) => !obj.extra_data.client?.includes("obsidian") && obj.parent_project_id == this.plugin.settings.pullFromProjectId);
-			return (filteredArray)
 
       }catch(err){
         console.error('An error occurred:', err);

--- a/src/todoistSyncAPI.ts
+++ b/src/todoistSyncAPI.ts
@@ -165,7 +165,7 @@ export class TodoistSyncAPI   {
         //console.log(allActivity)
         const allActivityEvents = allActivity.events
         //client中不包含obsidian 的activity
-        const filteredArray = allActivityEvents.filter(obj => !obj.extra_data.client?.includes("obsidian")
+        const filteredArray = allActivityEvents.filter(obj => !obj.extra_data.client?.includes("obsidian"))
         //console.log(filteredArray)
         return(filteredArray)
 

--- a/src/todoistSyncAPI.ts
+++ b/src/todoistSyncAPI.ts
@@ -168,6 +168,7 @@ export class TodoistSyncAPI   {
         const filteredArray = allActivityEvents.filter(obj => !obj.extra_data.client?.includes("obsidian")); 
         //console.log(filteredArray)
         return(filteredArray)
+			const filteredArray = allActivityEvents.filter((obj: Event) => !obj.extra_data.client?.includes("obsidian") && obj.parent_project_id == this.plugin.settings.pullFromProjectId);
 
       }catch(err){
         console.error('An error occurred:', err);

--- a/src/todoistSyncAPI.ts
+++ b/src/todoistSyncAPI.ts
@@ -165,7 +165,7 @@ export class TodoistSyncAPI   {
         //console.log(allActivity)
         const allActivityEvents = allActivity.events
         //client中不包含obsidian 的activity
-        const filteredArray = allActivityEvents.filter(obj => !obj.extra_data.client?.includes("obsidian") && this.plugin.settings.pullFromProjectId.includes(obj.parent_project_id) );
+        const filteredArray = allActivityEvents.filter(obj => !obj.extra_data.client?.includes("obsidian")
         //console.log(filteredArray)
         return(filteredArray)
 


### PR DESCRIPTION
Hi,

because i need this functionality for my own workflow, i implement it myself, today.
This is my first contribution to obsidian, so feel free to give some hints. Also there were some mistakes by myself with my IDE, because it tries to force me to use the code linter. But i do not found any information about the settings, the author used.

After this PR you can now:
- create a task in Todoist and it gets synced with obsidian
  - new setting options added for two modes
  - the daily note mode adds the tasks to the daily note
  - the template note mode adds the tasks to a separate note or a note specific to corresponding project
  - both modes supports `append to file` and `Insert After` a specified text
- you can add a task to obsidian as before and if something goes wrong, it fixes now automatically itself
  - it searches the vault for tasks with the same task text from todoist
  - this will helps to get a correct database state, if there was a network / code error
- fixes some minor typos and bugs i found on the go, e.g. the settings shows the selected default project twice

This should implement the most of wanted features for #53 

Missing things:
- Projects notes will not be deleted in obsidian, when deleted in Todoist
- tags are not supported right now, so they are missing in obsidian, when added in Todoist

So hopefully, we can get a step closer to the ultimate sync plugin.

One thing, i would like to add: Maybe we should start to translate everything to english, so more people can help. Also we should introduce a common linter config. I have no hard feelings here, so feel free to decide. :)

I am looking forward to hear from you.
Have a great day.