### PR TITLE
💄  Fix issue#69 Single line comments are hidden

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,12 @@
-
-.cm-line:not(:hover):not(.cm-active) span.cm-comment {
-    display: none;
+/* 
+ * Hide the todoist_id start and end comment delimiters (%%) 
+ * except when we hover over the line or edit the task
+ */
+.cm-line:not(:hover):not(.cm-active) > .cm-comment.cm-comment-start:has(~ .dataview.inline-field > .dataview.inline-field-key[data-dv-key="todoist_id"]),
+.cm-line:not(:hover):not(.cm-active) > .cm-comment.cm-comment-start:has(~ .dataview.inline-field > .dataview.inline-field-key[data-dv-key="todoist_id"]) ~ .cm-comment.cm-comment-end
+{
+		display: none;
 }
-
 
 
 


### PR DESCRIPTION
This PR is my attempt to fix [issue#69](https://github.com/HeroBlackInk/ultimate-todoist-sync-for-obsidian/issues/69#issuecomment-1816612760) where non-Todoist single-line comments in a language code block were hidden (Java, Ruby, HTML...) when the `ultimate-todoist-sync-for-obsidian` plugin was enabled.

@HeroBlackInk I am open to suggestions and would like your guidance to correct this PR if I miss something obvious. 

### What?

Modified the plugin's stylesheet to replace  
the [original CSS selector](https://github.com/HeroBlackInk/ultimate-todoist-sync-for-obsidian/blob/29b0c63577c8ff8405bd63c9e35145abf2b9b1b7/styles.css#L2-L4)
```css
.cm-line:not(:hover):not(.cm-active) span.cm-comment {
    display: none;
}
```
with this one:
```css
.cm-line:not(:hover):not(.cm-active) > .cm-comment.cm-comment-start:has(~ .dataview.inline-field > .dataview.inline-field-key[data-dv-key="todoist_id"]),
.cm-line:not(:hover):not(.cm-active) > .cm-comment.cm-comment-start:has(~ .dataview.inline-field > .dataview.inline-field-key[data-dv-key="todoist_id"]) ~ .cm-comment.cm-comment-end
{
    display: none;
}
```
The new selector **only** targets and hides the start and end delimiters (`%%`) of a `todoist_id` comment. The original selector also targeted other comment types.


### Why?

When you add a task tagged  `#todoist`, the `ultimate-todoist-sync-for-obsidian` plugin  automatically creates that task in Todoist and then adds the ID of that Todoist task in an Obsidian comment using this format:
> ```
> %%[todoist_id:: 123456789]%%
> ```
> where `123456789` is the ID of the task the plugin created on Todoist (external ID).
>
> By default, the plugin's CSS stylesheet hides the Obsidian start and end delimiters (`%%`) of the `todoist_id`  comment and only shows them when we hover over the line containing the comment.
> 
> ❌ The original CSS selector used to do this is not specific enough and also hides non-Todoist comments whereas it should not. For example, it hides all single-line comments in a language code block (See issue#69 for more details).
> 
> ✅ The fixed CSS selector**only** hides the start and end Todoist comment delimiters and continues showing other single-line comments in language code blocks.


### Tests

Here is the Obsidian note I used for my tests.

[Obsidian Test Note](https://github.com/HeroBlackInk/ultimate-todoist-sync-for-obsidian/files/13396819/Issue.69.Test.md)
