### PR TITLE
Add App URIs for links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ userData
 
 # Exclude macOS Finder (System Explorer) View States
 .DS_Store
+
+
+# Add js build artifacts
+*.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-	"name": "obsidian-sample-plugin",
+	"name": "ultimate-todoist-sync",
 	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "obsidian-sample-plugin",
+			"name": "ultimate-todoist-sync",
 			"version": "1.0.0",
-			"license": "MIT",
+			"license": "GNU GPLv3",
 			"dependencies": {
 				"@doist/todoist-api-typescript": "^2.1.2"
 			},

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -21,6 +21,7 @@ export interface UltimateTodoistSyncSettings {
 	enableFullVaultSync: boolean;
 	statistics: any;
 	debugMode:boolean;
+	useAppURI:boolean;
 }
 
 
@@ -34,6 +35,7 @@ export const DEFAULT_SETTINGS: UltimateTodoistSyncSettings = {
 	enableFullVaultSync:false,
 	statistics:{},
 	debugMode:false,
+	useAppURI:true,
 	//mySetting: 'default',
 	//todoistTasksFilePath: 'todoistTasks.json'
 
@@ -396,6 +398,19 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
 					this.plugin.todoistSync.backupTodoistAllResources()
 				})
 			);
+
+		new Setting(containerEl)
+			.setName('Use Desktop URIs')
+			.setDesc('If enabled produces application URI links (todoist://...) instead of web urls (https://...), which open in the app instead of the browser')
+			.addToggle(component => 
+				component
+						.setValue(this.plugin.settings.useAppURI)
+						.onChange((value)=>{
+							this.plugin.settings.useAppURI = value
+							this.plugin.saveSettings()						
+						})
+						
+				)
 	}
 }
 

--- a/src/syncModule.ts
+++ b/src/syncModule.ts
@@ -154,7 +154,7 @@ export class TodoistSync  {
 
                 //todoist id 保存到 任务后面
                 const text_with_out_link = `${linetxt} %%[todoist_id:: ${todoist_id}]%%`;
-                const link = `[link](${newTask.url})`
+                const link = this.plugin.settings.useAppURI ? `[link](todoist://task?id=${newTask.id})` : `[link](${newTask.url})`
                 const text = this.plugin.taskParser.addTodoistLink(text_with_out_link,link)
                 const from = { line: cursor.line, ch: 0 };
                 const to = { line: cursor.line, ch: linetxt.length };


### PR DESCRIPTION
See #90 
Adds option to use todoist app URIs (`todoist://task?id=`) instead of the default web URL returned by the API.
This opens the link in the app instead of browser (at least on android, macOS and iOS - unsure about windows, probably works on linux). 