### PR TITLE
fix: use new todoist API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # npm
 node_modules
+.pixi
 
 # Don't include the compiled main.js file in the repo.
 # They should be uploaded to GitHub releases instead.

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ data.json
 AGENTS.md
 device-id
 /.stfolder/
+# pixi environments
+.pixi/*
+!.pixi/config.toml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "ultimate-todoist-sync",
-	"version": "1.0.0",
+	"version": "2.0.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ultimate-todoist-sync",
-			"version": "1.0.0",
+			"version": "2.0.3",
 			"license": "GNU GPLv3",
 			"dependencies": {
-				"@doist/todoist-api-typescript": "^6.5.0"
+				"@doist/todoist-sdk": "^10.1.0"
 			},
 			"devDependencies": {
 				"@types/node": "^16.11.6",
@@ -19,7 +19,7 @@
 				"esbuild": "0.17.3",
 				"obsidian": "latest",
 				"tslib": "2.4.0",
-				"typescript": "4.7.4"
+				"typescript": "5.6.3"
 			}
 		},
 		"node_modules/@codemirror/state": {
@@ -41,25 +41,50 @@
 				"w3c-keyname": "^2.2.4"
 			}
 		},
-		"node_modules/@doist/todoist-api-typescript": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-6.5.0.tgz",
-			"integrity": "sha512-Hvtqb0EsBTN4gz4xsQ+VbYasZeEhNxuNa+CrCcGB+YWoRJipMmm4dXmzceYXKT8gx8UgVdyV7CDIEXrFQC/hFw==",
+		"node_modules/@doist/todoist-sdk": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-10.1.0.tgz",
+			"integrity": "sha512-o4AM0YGcQLlNyHOZ126qCfa+FQHsgNOKWpfZCECtjm6a+7tsiU39E/em3Ihcaynh7nUkYRXEVC8RUQ0kkCkJXw==",
 			"license": "MIT",
 			"dependencies": {
 				"camelcase": "6.3.0",
 				"emoji-regex": "10.6.0",
-				"form-data": "4.0.4",
+				"form-data": "4.0.5",
 				"ts-custom-error": "^3.2.0",
 				"undici": "^7.16.0",
 				"uuid": "11.1.0",
-				"zod": "4.1.12"
+				"zod": "4.3.6"
 			},
 			"engines": {
-				"node": ">=20.0.0"
+				"node": ">=20.18.1"
 			},
 			"peerDependencies": {
-				"type-fest": "^4.12.0"
+				"type-fest": "^4.12.0 || ^5.5.0"
+			}
+		},
+		"node_modules/@doist/todoist-sdk/node_modules/form-data": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+			"license": "MIT",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/@doist/todoist-sdk/node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
@@ -419,6 +444,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
 			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"eslint-visitor-keys": "^3.3.0"
 			},
@@ -434,6 +460,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.1.tgz",
 			"integrity": "sha512-BISJ6ZE4xQsuL/FmsyRaiffpq977bMlsKfGHTQrOGFErfByxIe6iZTxPf/00Zon9b9a7iUykfQwejN3s2ZW/Bw==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
@@ -443,6 +470,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.1.tgz",
 			"integrity": "sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
@@ -466,6 +494,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
 			"integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
@@ -475,6 +504,7 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
 			"integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@humanwhocodes/object-schema": "^1.2.1",
 				"debug": "^4.1.1",
@@ -489,6 +519,7 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
 			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=12.22"
 			},
@@ -501,7 +532,8 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -612,7 +644,6 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.29.0.tgz",
 			"integrity": "sha512-ruKWTv+x0OOxbzIw9nW5oWlUopvP/IQDjB5ZqmTglLIoDTctLlAJpAQFpNPJP/ZI7hTT9sARBosEfaKbcFuECw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "5.29.0",
 				"@typescript-eslint/types": "5.29.0",
@@ -777,6 +808,7 @@
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
 			"dev": true,
+			"peer": true,
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
@@ -786,6 +818,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -802,6 +835,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -811,6 +845,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -825,7 +860,8 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
@@ -846,13 +882,15 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -900,6 +938,7 @@
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -921,6 +960,7 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -937,6 +977,7 @@
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -948,7 +989,8 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
@@ -966,13 +1008,15 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
 			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -1003,7 +1047,8 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/delayed-stream": {
 			"version": "1.0.0",
@@ -1031,6 +1076,7 @@
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
 			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"esutils": "^2.0.2"
 			},
@@ -1145,6 +1191,7 @@
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -1264,6 +1311,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
 			"integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
@@ -1277,6 +1325,7 @@
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -1286,6 +1335,7 @@
 			"resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
 			"integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"acorn": "^8.8.0",
 				"acorn-jsx": "^5.3.2",
@@ -1303,6 +1353,7 @@
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
 			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"estraverse": "^5.1.0"
 			},
@@ -1315,6 +1366,7 @@
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -1354,6 +1406,7 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1362,7 +1415,8 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/fast-glob": {
 			"version": "3.2.12",
@@ -1396,13 +1450,15 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/fastq": {
 			"version": "1.15.0",
@@ -1418,6 +1474,7 @@
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
 			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"flat-cache": "^3.0.4"
 			},
@@ -1442,6 +1499,7 @@
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
 			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -1458,6 +1516,7 @@
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
 			"integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"flatted": "^3.1.0",
 				"rimraf": "^3.0.2"
@@ -1470,29 +1529,15 @@
 			"version": "3.2.7",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-			"dev": true
-		},
-		"node_modules/form-data": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-			"license": "MIT",
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
@@ -1551,6 +1596,7 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
 			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -1571,6 +1617,7 @@
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
 			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"is-glob": "^4.0.3"
 			},
@@ -1583,6 +1630,7 @@
 			"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
 			"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
 			},
@@ -1599,6 +1647,7 @@
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true,
 			"license": "(MIT OR CC0-1.0)",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -1642,13 +1691,15 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
 			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -1706,6 +1757,7 @@
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
 			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
@@ -1722,6 +1774,7 @@
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.8.19"
 			}
@@ -1731,6 +1784,7 @@
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -1740,7 +1794,8 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
@@ -1777,6 +1832,7 @@
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -1785,13 +1841,15 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/js-sdsl": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
 			"integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
 			"dev": true,
+			"peer": true,
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/js-sdsl"
@@ -1802,6 +1860,7 @@
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -1813,19 +1872,22 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/levn": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
 			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
@@ -1839,6 +1901,7 @@
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
 			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"p-locate": "^5.0.0"
 			},
@@ -1853,7 +1916,8 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
@@ -1924,6 +1988,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -1950,7 +2015,8 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/obsidian": {
 			"version": "1.1.1",
@@ -1971,6 +2037,7 @@
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"wrappy": "1"
 			}
@@ -1980,6 +2047,7 @@
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
 			"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
@@ -1997,6 +2065,7 @@
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
 			},
@@ -2012,6 +2081,7 @@
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
 			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"p-limit": "^3.0.2"
 			},
@@ -2027,6 +2097,7 @@
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"callsites": "^3.0.0"
 			},
@@ -2039,6 +2110,7 @@
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2048,6 +2120,7 @@
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2057,6 +2130,7 @@
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2087,6 +2161,7 @@
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.8.0"
 			}
@@ -2096,6 +2171,7 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
 			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -2137,6 +2213,7 @@
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -2156,6 +2233,7 @@
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -2209,6 +2287,7 @@
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
 			},
@@ -2221,6 +2300,7 @@
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2239,6 +2319,7 @@
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -2251,6 +2332,7 @@
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -2262,13 +2344,15 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.2.tgz",
 			"integrity": "sha512-C4myMmRTO8iaC5Gg+N1ftK2WT4eXUTMAa+HEFPPrfVeO/NtqLTtAmV1HbqnuGtLwCek44Ra76fdGUkSqjiMPcQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -2280,7 +2364,8 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -2334,6 +2419,7 @@
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
 			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1"
 			},
@@ -2355,17 +2441,17 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+			"version": "5.6.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+			"integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
 			"dev": true,
-			"peer": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/undici": {
@@ -2382,6 +2468,7 @@
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
@@ -2403,13 +2490,15 @@
 			"version": "2.2.6",
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.6.tgz",
 			"integrity": "sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"isexe": "^2.0.0"
 			},
@@ -2425,6 +2514,7 @@
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
 			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2433,7 +2523,8 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/yallist": {
 			"version": "4.0.0",
@@ -2446,20 +2537,12 @@
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/zod": {
-			"version": "4.1.12",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
-			"integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
 		"esbuild": "0.17.3",
 		"obsidian": "latest",
 		"tslib": "2.4.0",
-		"typescript": "4.7.4"
+		"typescript": "5.6.3"
 	},
 	"dependencies": {
-		"@doist/todoist-api-typescript": "^6.5.0"
+		"@doist/todoist-sdk": "^10.1.0"
 	}
 }

--- a/src/api/restApi.ts
+++ b/src/api/restApi.ts
@@ -1,29 +1,74 @@
-import { TodoistApi } from "@doist/todoist-api-typescript"
-import { App} from 'obsidian';
+import { TodoistApi } from "@doist/todoist-sdk"
+import { App, requestUrl, type RequestUrlParam, type RequestUrlResponse } from 'obsidian';
 import UltimateTodoistSyncForObsidian from "../../main";
-    //convert date from obsidian event
-    // 使用示例
-    //const str = "2023-03-27";
-    //const utcStr = localDateStringToUTCDatetimeString(str);
-    //this.plugin.debugLog(dateStr); // 输出 2023-03-27T00:00:00.000Z
-function  localDateStringToUTCDatetimeString(localDateString:string) {
-        try {
-          if(localDateString === null){
-            return null
-          }
-          localDateString = localDateString + "T08:00";
-          let localDateObj = new Date(localDateString);
-          let ISOString = localDateObj.toISOString()
-          return(ISOString);
-        } catch (error) {
-          console.error(`Error extracting date from string '${localDateString}': ${error}`);
-          return null;
-        }
+type IdMappingObjectName = 'projects' | 'tasks' | 'sections';
+
+function normalizeRequestHeaders(headers?: HeadersInit): Record<string, string> {
+  if (!headers) {
+    return {};
+  }
+
+  if (headers instanceof Headers) {
+    const normalizedHeaders: Record<string, string> = {};
+    headers.forEach((value, key) => {
+      normalizedHeaders[key] = String(value);
+    });
+    return normalizedHeaders;
+  }
+
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers.map(([key, value]) => [key, String(value)]));
+  }
+
+  return Object.fromEntries(Object.entries(headers).map(([key, value]) => [key, String(value)]));
+}
+
+function normalizeResponseHeaders(headers: RequestUrlResponse['headers']): Record<string, string> {
+  if (!headers || typeof headers !== 'object') {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key, Array.isArray(value) ? value.join(', ') : String(value)])
+  );
+}
+
+function createObsidianFetchAdapter(requestUrlFn: (request: RequestUrlParam | string) => Promise<RequestUrlResponse>) {
+  return async (url: string, options?: RequestInit & { timeout?: number }) => {
+    const body = options?.body;
+    const normalizedBody = typeof body === 'string'
+      ? body
+      : body instanceof URLSearchParams
+        ? body.toString()
+        : body == null
+          ? undefined
+          : String(body);
+
+    const response = await requestUrlFn({
+      url,
+      method: options?.method ?? 'GET',
+      headers: normalizeRequestHeaders(options?.headers),
+      body: normalizedBody,
+      throw: false,
+    });
+
+    return {
+      ok: response.status >= 200 && response.status < 300,
+      status: response.status,
+      statusText: '',
+      headers: normalizeResponseHeaders(response.headers),
+      text: async () => typeof response.text === 'string' ? response.text : JSON.stringify(response.json ?? ''),
+      json: async () => response.json,
+    };
+  };
 }
 
 export class TodoistRestAPI  {
 	app:App;
   plugin: UltimateTodoistSyncForObsidian;
+  private api: TodoistApi | null = null;
+  private apiToken = '';
+  private readonly idMappingCache = new Map<string, string>();
 
 	constructor(app:App, plugin:UltimateTodoistSyncForObsidian) {
 		//super(app,settings);
@@ -31,29 +76,104 @@ export class TodoistRestAPI  {
     this.plugin = plugin;
 	}
 
-
-    initializeAPI(){
-        const token = this.plugin.settings.todoistAPIToken
-        const api = new TodoistApi(token)
-        return(api)
+  private getApi(): TodoistApi {
+    const token = this.plugin.settings.todoistAPIToken;
+    if (!token) {
+      throw new Error('Todoist API token is missing');
     }
 
-    async AddTask({ projectId, content, parentId = null, dueDate, dueDatetime,labels, description,priority }: { projectId: string, content: string, parentId?: string , dueDate?: string,dueDatetime?: string, labels?: Array<string>, description?: string,priority?:number }) {
-        const api = await this.initializeAPI()
+    if (!this.api || this.apiToken !== token) {
+      this.api = new TodoistApi(token, {
+        customFetch: createObsidianFetchAdapter(requestUrl),
+      });
+      this.apiToken = token;
+      this.idMappingCache.clear();
+    }
+
+    return this.api;
+  }
+
+  private isLegacyNumericId(id?: string | null): id is string {
+    return typeof id === 'string' && /^\d+$/.test(id);
+  }
+
+  async resolveId(objName: IdMappingObjectName, id?: string | null): Promise<string | undefined> {
+    if (!id) {
+      return undefined;
+    }
+
+    if (!this.isLegacyNumericId(id)) {
+      return id;
+    }
+
+    const cacheKey = `${objName}:${id}`;
+    const cached = this.idMappingCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const mappings = await this.getApi().getIdMappings({
+      objName,
+      objIds: [id],
+    });
+
+    const resolved = mappings.find((entry) => entry.oldId === id)?.newId ?? id;
+    if (resolved && resolved !== id) {
+      this.idMappingCache.set(cacheKey, resolved);
+    }
+
+    return resolved;
+  }
+
+  async resolveIds(objName: IdMappingObjectName, ids: string[]): Promise<Record<string, string>> {
+    const uniqueIds = Array.from(new Set(ids.filter((id): id is string => this.isLegacyNumericId(id))));
+    if (uniqueIds.length === 0) {
+      return {};
+    }
+
+    const uncached = uniqueIds.filter((id) => !this.idMappingCache.has(`${objName}:${id}`));
+    if (uncached.length > 0) {
+      const mappings = await this.getApi().getIdMappings({
+        objName,
+        objIds: uncached as [string, ...string[]],
+      });
+
+      for (const mapping of mappings) {
+        if (mapping.oldId && mapping.newId) {
+          this.idMappingCache.set(`${objName}:${mapping.oldId}`, mapping.newId);
+        }
+      }
+    }
+
+    return Object.fromEntries(uniqueIds.map((id) => [id, this.idMappingCache.get(`${objName}:${id}`) ?? id]));
+  }
+
+    initializeAPI(){
+        return this.getApi()
+    }
+
+    async AddTask({ projectId, content, parentId, dueDate, dueDatetime,labels, description,priority }: { projectId?: string, content: string, parentId?: string | null , dueDate?: string,dueDatetime?: string, labels?: Array<string>, description?: string,priority?:number }) {
+        const api = this.initializeAPI()
         try {
-          if(dueDate){
-            dueDatetime = localDateStringToUTCDatetimeString(dueDate)
-            dueDate = undefined
-          }  
-          const newTask = await api.addTask({
-            projectId,
-            content,
-            parentId,
-            dueDate,
-            labels,
-            description,
-            priority
-          });
+      const addTaskArgs: Record<string, unknown> = {
+        content,
+        parentId: parentId || undefined,
+        labels,
+        description,
+        priority,
+      };
+
+      if (projectId) {
+        addTaskArgs.projectId = projectId;
+      }
+
+      if (dueDate) {
+        addTaskArgs.dueDate = dueDate;
+      } else if (dueDatetime) {
+        addTaskArgs.dueDatetime = dueDatetime;
+      }
+
+      const newTask = await api.addTask(addTaskArgs as any);
           return newTask;
         } catch (error) {
           throw new Error(`Error adding task: ${error.message}`);
@@ -63,11 +183,15 @@ export class TodoistRestAPI  {
 
     //options:{ projectId?: string, section_id?: string, label?: string , filter?: string,lang?: string, ids?: Array<string>}
     async GetActiveTasks(options:{ projectId?: string, section_id?: string, label?: string , filter?: string,lang?: string, ids?: Array<string>}) {
-      const api = await this.initializeAPI()
+      const api = this.initializeAPI()
       try {
-        const result = await api.getTasks(options);
-        // API v1 返回分页格式 { results: [], nextCursor: null }
-        return result.results || result;
+        const result = await api.getTasks({
+			projectId: options.projectId,
+			sectionId: options.section_id,
+			label: options.label,
+			ids: options.ids,
+		});
+        return result.results;
       } catch (error) {
         throw new Error(`Error get active tasks: ${error.message}`);
       }
@@ -77,7 +201,7 @@ export class TodoistRestAPI  {
     //Also note that to remove the due date of a task completely, you should set the due_string parameter to no date or no due date.
     //api 没有 update task project id 的函数
     async UpdateTask(taskId: string, updates: { content?: string, description?: string, labels?:Array<string>,dueDate?: string,dueDatetime?: string,dueString?:string,parentId?:string,priority?:number }) {
-        const api = await this.initializeAPI()
+        const api = this.initializeAPI()
         if (!taskId) {
         throw new Error('taskId is required');
         }
@@ -85,13 +209,26 @@ export class TodoistRestAPI  {
         throw new Error('At least one update is required');
         }
         try {
-        if(updates.dueDate){
-            this.plugin.debugLog(updates.dueDate)
-            updates.dueDatetime = localDateStringToUTCDatetimeString(updates.dueDate)
-            updates.dueDate = null
-            this.plugin.debugLog(updates.dueDatetime)
-          }  
-        const updatedTask = await api.updateTask(taskId, updates);
+        if (updates.parentId) {
+			await api.moveTask(taskId, { parentId: updates.parentId });
+		}
+
+    const updateTaskArgs: Record<string, unknown> = {
+      content: updates.content,
+      description: updates.description,
+      labels: updates.labels,
+      priority: updates.priority,
+    };
+
+    if (updates.dueDate) {
+      updateTaskArgs.dueDate = updates.dueDate;
+    } else if (updates.dueDatetime) {
+      updateTaskArgs.dueDatetime = updates.dueDatetime;
+    } else if (updates.dueString !== undefined) {
+      updateTaskArgs.dueString = updates.dueString || null;
+    }
+
+    const updatedTask = await api.updateTask(taskId, updateTaskArgs as any);
         return updatedTask;
         } catch (error) {
         throw new Error(`Error updating task: ${error.message}`);
@@ -102,23 +239,22 @@ export class TodoistRestAPI  {
 
 
     //open a task
-    async OpenTask(taskId:string) {
-        const api = await this.initializeAPI()
+    async OpenTask(taskId:string): Promise<boolean> {
+      const api = this.initializeAPI()
         try {
-    
         const isSuccess = await api.reopenTask(taskId);
         this.plugin.debugLog(`Task ${taskId} is reopend`)
         return(isSuccess)
     
         } catch (error) {
             console.error('Error open a  task:', error);
-            return
+            throw error;
         }
     }
 
     // Close a task in Todoist API
     async CloseTask(taskId: string): Promise<boolean> {
-        const api = await this.initializeAPI()
+      const api = this.initializeAPI()
         try {
         const isSuccess = await api.closeTask(taskId);
         this.plugin.debugLog(`Task ${taskId} is closed`)
@@ -134,7 +270,7 @@ export class TodoistRestAPI  {
  
     // get a task by Id
     async getTaskById(taskId: string) {
-        const api = await this.initializeAPI()
+      const api = this.initializeAPI()
         if (!taskId) {
         throw new Error('taskId is required');
         }
@@ -153,7 +289,7 @@ export class TodoistRestAPI  {
 
     //get a task due by id
     async getTaskDueById(taskId: string) {
-        const api = await this.initializeAPI()
+      const api = this.initializeAPI()
         if (!taskId) {
         throw new Error('taskId is required');
         }
@@ -169,17 +305,32 @@ export class TodoistRestAPI  {
 
     //get all projects
     async GetAllProjects() {
-        const api = await this.initializeAPI()
+        const api = this.initializeAPI()
         try {
-        const result = await api.getProjects();
-        // API v1 返回分页格式 { results: [], nextCursor: null }
-        return result.results || result;
+        const projects = [];
+    let cursor: string | null = null;
+    do {
+      const result = await api.getProjects({ cursor: cursor ?? undefined, limit: 200 });
+      projects.push(...result.results);
+      cursor = result.nextCursor;
+    } while (cursor);
+
+    return projects;
     
         } catch (error) {
             console.error('Error get all projects', error);
             return false
         }
     }
+
+  async DeleteTask(taskId: string): Promise<boolean> {
+    const api = this.initializeAPI();
+    try {
+      return await api.deleteTask(taskId);
+    } catch (error) {
+      throw new Error(`Error deleting task: ${error.message}`);
+    }
+  }
 
 
 }

--- a/src/api/syncApi.ts
+++ b/src/api/syncApi.ts
@@ -315,6 +315,14 @@ export class TodoistSyncAPI   {
 		return await this.deviceManager.getClientHeader();
 	}
 
+  private async resolveLegacyId(objName: 'projects' | 'tasks' | 'sections', id?: string | null): Promise<string | undefined> {
+    if (!id) {
+      return undefined;
+    }
+
+    return await this.plugin.todoistRestAPI?.resolveId(objName, id);
+  }
+
 	async initializeSync(): Promise<void> {
 		// Route through incrementalSync lock so concurrent callers wait
 		if (this._syncRunning) {
@@ -840,25 +848,25 @@ export class TodoistSyncAPI   {
     due?: { string?: string; date?: string; datetime?: string };
     priority?: number;
     description?: string;
-  }): Promise<{ id: string }> {
-    const tempId = this.generateTempId();
-    const command = {
-      type: 'item_add',
-      uuid: this.generateUUID(),
-      temp_id: tempId,
-      args: args
-    };
+    labels?: string[];
+  }): Promise<any> {
+    const todoistRestAPI = this.plugin.todoistRestAPI;
+    if (!todoistRestAPI) {
+      throw new Error('Todoist REST API is not initialized');
+    }
 
-    const result = await this.executeCommands([command]);
-    if (result && result.temp_id_mapping && result.temp_id_mapping[tempId]) {
-      return { id: result.temp_id_mapping[tempId] };
-    }
-    const cmdStatus = result?.sync_status?.[command.uuid];
-    if (cmdStatus && cmdStatus !== 'ok') {
-      const err = cmdStatus as { error?: string; error_code?: number };
-      throw new Error(`Failed to add task: ${err.error || JSON.stringify(cmdStatus)}`);
-    }
-    throw new Error(`Failed to add task: no temp_id_mapping in response. Response: ${JSON.stringify(result)}`);
+    const projectId = await this.resolveLegacyId('projects', args.project_id);
+    const parentId = await this.resolveLegacyId('tasks', args.parent_id);
+    return await todoistRestAPI.AddTask({
+      projectId: projectId || undefined,
+      content: args.content,
+      parentId,
+      dueDate: args.due?.date,
+      dueDatetime: args.due?.datetime,
+      labels: args.labels,
+      description: args.description,
+      priority: args.priority,
+    });
   }
 
   // Update task using Sync API
@@ -866,60 +874,61 @@ export class TodoistSyncAPI   {
     content?: string;
     description?: string;
     priority?: number;
-    due?: { string?: string; date?: string };
-  }): Promise<boolean> {
-    const command = {
-      type: 'item_update',
-      uuid: this.generateUUID(),
-      args: {
-        id: taskId,
-        ...args
-      }
-    };
+    labels?: string[];
+    parent_id?: string;
+    due?: { string?: string; date?: string; datetime?: string };
+  }): Promise<any> {
+    const todoistRestAPI = this.plugin.todoistRestAPI;
+    if (!todoistRestAPI) {
+      throw new Error('Todoist REST API is not initialized');
+    }
 
-    await this.executeCommands([command]);
-    return true;
+    const resolvedTaskId = await this.resolveLegacyId('tasks', taskId);
+    return await todoistRestAPI.UpdateTask(resolvedTaskId || taskId, {
+      content: args.content,
+      description: args.description,
+      labels: args.labels,
+      dueDate: args.due?.date,
+      dueDatetime: args.due?.datetime,
+      dueString: args.due?.string,
+      parentId: await this.resolveLegacyId('tasks', args.parent_id),
+      priority: args.priority,
+    });
   }
 
   // Close task using Sync API
   async closeTask(taskId: string): Promise<boolean> {
-    const command = {
-      type: 'item_close',
-      uuid: this.generateUUID(),
-      args: {
-        id: taskId
-      }
-    };
+    const todoistRestAPI = this.plugin.todoistRestAPI;
+    if (!todoistRestAPI) {
+      throw new Error('Todoist REST API is not initialized');
+    }
 
-    await this.executeCommands([command]);
-    return true;
+    const resolvedTaskId = await this.resolveLegacyId('tasks', taskId);
+    return await todoistRestAPI.CloseTask(resolvedTaskId || taskId);
   }
 
   // Reopen task using Sync API (item_uncomplete per official docs)
   async reopenTask(taskId: string): Promise<boolean> {
-    const command = {
-      type: 'item_uncomplete',
-      uuid: this.generateUUID(),
-      args: {
-        id: taskId
-      }
-    };
+    const todoistRestAPI = this.plugin.todoistRestAPI;
+    if (!todoistRestAPI) {
+      throw new Error('Todoist REST API is not initialized');
+    }
 
-    await this.executeCommands([command]);
-    return true;
+    const resolvedTaskId = await this.resolveLegacyId('tasks', taskId);
+    return await todoistRestAPI.OpenTask(resolvedTaskId || taskId);
   }
 
   // Compatible wrapper: AddTask
   async AddTask(task: {
     projectId: string;
     content: string;
-    parentId?: string;
+    parentId?: string | null;
     dueDate?: string;
     dueDatetime?: string;
     labels?: string[];
     description?: string;
     priority?: number;
-  }): Promise<{ id: string }> {
+  }): Promise<any> {
     const args: any = {
       content: task.content,
     };
@@ -963,7 +972,7 @@ export class TodoistSyncAPI   {
     dueString?: string;
     parentId?: string;
     priority?: number;
-  }): Promise<boolean> {
+  }): Promise<any> {
     const args: any = {};
 
     if (updates.content) args.content = updates.content;
@@ -1009,6 +1018,7 @@ export class TodoistSyncAPI   {
   // Compatible wrapper: GetTaskById
   async GetTaskById(taskId: string, options?: { allowNetworkRefresh?: boolean }): Promise<any> {
     try {
+      taskId = (await this.resolveLegacyId('tasks', taskId)) || taskId;
       const allowNetworkRefresh = options?.allowNetworkRefresh !== false;
 
       if (!this.syncData) {
@@ -1061,10 +1071,13 @@ export class TodoistSyncAPI   {
         this.syncData = await this.getAllResources(true);
       }
       let tasks = this.syncData?.items || [];
+      const resolvedProjectId = options?.projectId
+        ? await this.resolveLegacyId('projects', options.projectId)
+        : undefined;
 
       if (options) {
-        if (options.projectId) {
-          tasks = tasks.filter((t: any) => t.project_id === options.projectId);
+        if (resolvedProjectId) {
+          tasks = tasks.filter((t: any) => t.project_id === resolvedProjectId);
         }
         if (options.section_id) {
           tasks = tasks.filter((t: any) => t.section_id === options.section_id);
@@ -1087,6 +1100,7 @@ export class TodoistSyncAPI   {
   // Get project by ID from syncData
   async getProjectById(projectId: string): Promise<any> {
     try {
+      projectId = (await this.resolveLegacyId('projects', projectId)) || projectId;
       if (!this.syncData) {
         this.syncData = await this.getAllResources(true);
       }
@@ -1119,16 +1133,13 @@ export class TodoistSyncAPI   {
 
   // Delete task using Sync API
   async deleteTask(taskId: string): Promise<boolean> {
-    const command = {
-      type: 'item_delete',
-      uuid: this.generateUUID(),
-      args: {
-        id: taskId
-      }
-    };
+    const todoistRestAPI = this.plugin.todoistRestAPI;
+    if (!todoistRestAPI) {
+      throw new Error('Todoist REST API is not initialized');
+    }
 
-    await this.executeCommands([command]);
-    return true;
+    const resolvedTaskId = await this.resolveLegacyId('tasks', taskId);
+    return await todoistRestAPI.DeleteTask(resolvedTaskId || taskId);
   }
 
   /**

--- a/src/api/syncApi.ts
+++ b/src/api/syncApi.ts
@@ -456,13 +456,13 @@ export class TodoistSyncAPI   {
     		method: 'POST',
     		headers: {
     			'Authorization': `Bearer ${accessToken}`,
- 				'Content-Type': 'application/x-www-form-urlencoded',
+ 				'Content-Type': 'application/json',
  				'X-Todoist-Client': clientId
     		},
-    		body: new URLSearchParams({
+    		body: JSON.stringify({
     			sync_token: syncToken,
-    			resource_types: '["all"]'
-    		}).toString()
+    			resource_types: ['all'],
+    		}),
     	};
   
 	    	try {
@@ -522,12 +522,12 @@ export class TodoistSyncAPI   {
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${accessToken}`,
-          'Content-Type': 'application/x-www-form-urlencoded'
+          'Content-Type': 'application/json',
         },
-        body: new URLSearchParams({
-          sync_token: "*",
-          resource_types: '["user_plan_limits"]'
-        }).toString()
+        body: JSON.stringify({
+          sync_token: '*',
+          resource_types: ['user_plan_limits'],
+        }),
       };
     
       try {
@@ -565,15 +565,15 @@ export class TodoistSyncAPI   {
           method: 'POST',
           headers: {
             'Authorization': `Bearer ${accessToken}`,
-            'Content-Type': 'application/x-www-form-urlencoded'
+            'Content-Type': 'application/json',
           },
-          body: new URLSearchParams({ commands: JSON.stringify(commands) }).toString()
+          body: JSON.stringify({ commands }),
         };
-      
+
         try {
           const response = await requestUrl(options);
 		  this.assertSuccessfulResponse('updateUserTimezone', response);
-      
+
           const data = response.json;
           this.plugin.debugLog(data)
           return data;
@@ -799,12 +799,10 @@ export class TodoistSyncAPI   {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${accessToken}`,
- 		'Content-Type': 'application/x-www-form-urlencoded',
+ 		'Content-Type': 'application/json',
  		'X-Todoist-Client': clientId
       },
-      body: new URLSearchParams({
-        commands: JSON.stringify(commands)
-      }).toString()
+      body: JSON.stringify({ commands }),
     };
 
     try {

--- a/src/data/cache.ts
+++ b/src/data/cache.ts
@@ -990,7 +990,7 @@ export class CacheOperation   {
     // ==========================================================================================
 
     // DEPRECATED: Using syncData from Todoist API instead - no longer needed
-    loadTasksFromCache() {
+    loadTasksFromCache(): any[] {
         return [];
     }
 

--- a/src/storage/pathManager.ts
+++ b/src/storage/pathManager.ts
@@ -237,7 +237,7 @@ export class StoragePathManager {
         try {
             const file = this.app.vault.getAbstractFileByPath(path);
             if (file && 'stat' in file) {
-                return file.stat.mtime;
+                return (file as { stat: { mtime: number } }).stat.mtime;
             }
             return 0;
         } catch {

--- a/src/sync/scheduler.ts
+++ b/src/sync/scheduler.ts
@@ -25,7 +25,7 @@ export class SyncScheduler {
 			if (Date.now() - lastFullSync > FULL_SYNC_INTERVAL) {
 				this.plugin.debugLog('Periodic full sync triggered');
 				try {
-					await this.plugin.todoistSyncAPI.initializeSync();
+					await this.plugin.todoistSyncAPI?.initializeSync();
 					await this.plugin.safeSettings?.update({ lastFullSyncTime: Date.now() }, true);
 				} catch (error) {
 					console.error('[Scheduler] Periodic full sync failed:', error);

--- a/src/sync/toObsidian.ts
+++ b/src/sync/toObsidian.ts
@@ -1,5 +1,5 @@
 import UltimateTodoistSyncForObsidian from "../../main";
-import { App, Notice } from 'obsidian';
+import { App, Notice, TFile } from 'obsidian';
 import { StoragePathManager } from '../storage/pathManager';
 
 export class TodoistToObsidianSync {
@@ -108,7 +108,7 @@ export class TodoistToObsidianSync {
             return;
         }
 
-        const fileContent = await this.app.vault.read(file);
+        const fileContent = await this.app.vault.read(file as TFile);
         const lines = fileContent.split('\n');
 
         let taskLine = '';
@@ -197,7 +197,12 @@ export class TodoistToObsidianSync {
 
     async backupTodoistAllResources(): Promise<void> {
         try {
-            const resources = await this.plugin.todoistSyncAPI.getAllResources(true);
+            const todoistSyncAPI = this.plugin.todoistSyncAPI;
+            if (!todoistSyncAPI) {
+                throw new Error('Todoist sync API is not initialized');
+            }
+
+            const resources = await todoistSyncAPI.getAllResources(true);
 
             const now: Date = new Date();
             const timeString = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}-${String(now.getHours()).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}${String(now.getSeconds()).padStart(2, '0')}`;

--- a/src/sync/toObsidian.ts
+++ b/src/sync/toObsidian.ts
@@ -15,9 +15,9 @@ export class TodoistToObsidianSync {
         try {
             this.plugin.logOperation?.log('SYNC_START', 'Starting sync from Todoist to Obsidian', undefined, undefined, 'todoist→obsidian');
 
-            await this.plugin.todoistSyncAPI.incrementalSync();
+            await this.plugin.todoistSyncAPI!.incrementalSync();
 
-            const syncData = this.plugin.todoistSyncAPI.getSyncData();
+            const syncData = this.plugin.todoistSyncAPI!.getSyncData();
             if (!syncData?.items) {
                 this.plugin.debugLog('[Todoist→Obsidian] No sync data available');
                 return;
@@ -67,7 +67,7 @@ export class TodoistToObsidianSync {
                     try {
                         await this.syncSingleTaskToObsidian(taskId, task);
                         syncedCount++;
-                        await this.plugin.cacheOperation.updateTaskMappingSyncMeta(taskId, {
+                        await this.plugin.cacheOperation!.updateTaskMappingSyncMeta(taskId, {
                             updated_at: task.updated_at,
                             note_count: task.note_count || 0
                         });
@@ -92,7 +92,7 @@ export class TodoistToObsidianSync {
     }
 
     private async syncSingleTaskToObsidian(taskId: string, task: any): Promise<void> {
-        const mapping = this.plugin.cacheOperation.getTaskFileMapping(taskId);
+        const mapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId);
         if (!mapping) {
             console.warn(`[syncSingleTaskToObsidian] No mapping found for task ${taskId}`);
             this.plugin.debugLog(`[syncSingleTaskToObsidian] No mapping found for task ${taskId}`);
@@ -113,7 +113,7 @@ export class TodoistToObsidianSync {
 
         let taskLine = '';
         for (const line of lines) {
-            if (line.includes(taskId) && this.plugin.taskParser.hasTodoistTag(line)) {
+            if (line.includes(taskId) && this.plugin.taskParser!.hasTodoistTag(line)) {
                 taskLine = line;
                 break;
             }
@@ -129,34 +129,34 @@ export class TodoistToObsidianSync {
         const todoistIsChecked = task.checked || false;
 
         if (todoistIsChecked && !obsidianIsChecked) {
-            await this.plugin.fileOperation.completeTaskInTheFile(taskId);
+            await this.plugin.fileOperation!.completeTaskInTheFile(taskId);
             new Notice(`Task ${taskId} completed from Todoist`);
             this.plugin.logOperation?.log('TODOIST_TASK_COMPLETED', `Task completed in Todoist: ${taskId}`, mapping.filePath, taskId, 'todoist→obsidian');
         } else if (!todoistIsChecked && obsidianIsChecked) {
-            await this.plugin.fileOperation.uncompleteTaskInTheFile(taskId);
+            await this.plugin.fileOperation!.uncompleteTaskInTheFile(taskId);
             new Notice(`Task ${taskId} reopened from Todoist`);
             this.plugin.logOperation?.log('TODOIST_TASK_REOPENED', `Task reopened in Todoist: ${taskId}`, mapping.filePath, taskId, 'todoist→obsidian');
         }
 
-        const obsidianContent = this.plugin.taskParser.getTaskContentFromLineText(taskLine);
+        const obsidianContent = this.plugin.taskParser!.getTaskContentFromLineText(taskLine);
         if (obsidianContent && task.content && obsidianContent !== task.content) {
-            await this.plugin.fileOperation.syncTaskContentToFile(taskId, task.content);
+            await this.plugin.fileOperation!.syncTaskContentToFile(taskId, task.content);
             this.plugin.logOperation?.log('FILE_TASK_CONTENT_SYNCED', `Synced content: ${taskId}`, mapping.filePath, taskId, 'todoist→obsidian');
         }
 
-        const obsidianDueDate = this.plugin.taskParser.getDueDateFromLineText(taskLine) || "";
-        const todoistDueDate = task.due?.date ? (this.plugin.taskParser.ISOStringToLocalDateString(task.due.date) || "") : "";
+        const obsidianDueDate = this.plugin.taskParser!.getDueDateFromLineText(taskLine) || "";
+        const todoistDueDate = task.due?.date ? (this.plugin.taskParser!.ISOStringToLocalDateString(task.due.date) || "") : "";
         if (obsidianDueDate !== todoistDueDate) {
-            await this.plugin.fileOperation.syncTaskDueDateToFile(taskId, task.due?.date || "");
+            await this.plugin.fileOperation!.syncTaskDueDateToFile(taskId, task.due?.date || "");
             this.plugin.logOperation?.log('FILE_TASK_DUEDATE_SYNCED', `Synced due date: ${taskId}`, mapping.filePath, taskId, 'todoist→obsidian');
         }
 
-        const prioritySynced = await this.plugin.fileOperation.syncTaskPriorityToFile(taskId, task.priority || 1);
+        const prioritySynced = await this.plugin.fileOperation!.syncTaskPriorityToFile(taskId, task.priority || 1);
         if (prioritySynced) {
             this.plugin.logOperation?.log('FILE_TASK_PRIORITY_SYNCED', `Synced priority: ${taskId}`, mapping.filePath, taskId, 'todoist→obsidian');
         }
 
-        const labelsSynced = await this.plugin.fileOperation.syncTaskLabelsToFile(taskId, task.labels || []);
+        const labelsSynced = await this.plugin.fileOperation!.syncTaskLabelsToFile(taskId, task.labels || []);
         if (labelsSynced) {
             this.plugin.logOperation?.log('FILE_TASK_LABELS_SYNCED', `Synced labels: ${taskId}`, mapping.filePath, taskId, 'todoist→obsidian');
         }
@@ -181,15 +181,15 @@ export class TodoistToObsidianSync {
             const newNotes = sortedNotes.slice(storedNoteCount);
             for (const note of newNotes) {
                 try {
-                    const dateStr = this.plugin.taskParser.ISOStringToLocalDatetimeString(note.posted_at || note.added_at || '');
-                    await this.plugin.fileOperation.syncTaskNoteToFile(taskId, note.content || '', dateStr);
+                    const dateStr = this.plugin.taskParser!.ISOStringToLocalDatetimeString(note.posted_at || note.added_at || '');
+                    await this.plugin.fileOperation!.syncTaskNoteToFile(taskId, note.content || '', dateStr ?? '');
                     new Notice(`Note synced to task ${taskId}`);
                 } catch (error) {
                     console.error(`[Todoist→Obsidian] Error syncing note for task ${taskId}:`, error);
                 }
             }
 
-            await this.plugin.cacheOperation.updateTaskMappingSyncMeta(taskId, {
+            await this.plugin.cacheOperation!.updateTaskMappingSyncMeta(taskId, {
                 note_count: notes.length
             });
         }

--- a/src/sync/toObsidian.ts
+++ b/src/sync/toObsidian.ts
@@ -40,14 +40,20 @@ export class TodoistToObsidianSync {
             const taskFileMapping = this.plugin.settings.taskFileMapping || {};
             let syncedCount = 0;
 
+            // Resolve legacy numeric IDs → new string IDs so we can look up
+            // tasks in the Sync API response (which uses new IDs).
+            const cacheTaskIds = Object.keys(taskFileMapping);
+            const idMapping = await this.resolveTaskIds(cacheTaskIds);
+
             // Set flag: file writes below are from Todoist pull, not user edits
             this.plugin.isSyncingFromTodoist = true;
             try {
-                for (const taskId of Object.keys(taskFileMapping)) {
+                for (const taskId of cacheTaskIds) {
                     const mapping = taskFileMapping[taskId];
                     if (mapping.syncEnabled === false) continue;
 
-                    const task = itemMap.get(taskId);
+                    const resolvedId = idMapping[taskId] || taskId;
+                    const task = itemMap.get(resolvedId) || itemMap.get(taskId);
 
                     if (!task || task.is_deleted) {
                         if (this.plugin.settings.debugMode) {
@@ -76,7 +82,7 @@ export class TodoistToObsidianSync {
                     }
                 }
 
-                await this.syncNotesToObsidian(taskFileMapping, noteMap);
+                await this.syncNotesToObsidian(taskFileMapping, noteMap, idMapping);
             } finally {
                 this.plugin.isSyncingFromTodoist = false;
             }
@@ -164,9 +170,22 @@ export class TodoistToObsidianSync {
 
     private async syncNotesToObsidian(
         taskFileMapping: Record<string, { note_count?: number; syncEnabled?: boolean }>,
-        noteMap: Map<string, any[]>
+        noteMap: Map<string, any[]>,
+        idMapping: Record<string, string>
     ): Promise<void> {
-        for (const [taskId, notes] of noteMap.entries()) {
+        // Build reverse map: newId → cacheId so we can look up noteMap entries
+        // (keyed by new IDs from syncData) against taskFileMapping (keyed by
+        // cache IDs which may be legacy numeric IDs).
+        const reverseIdMap = new Map<string, string>();
+        for (const [cacheId, resolvedId] of Object.entries(idMapping)) {
+            if (resolvedId !== cacheId) {
+                reverseIdMap.set(resolvedId, cacheId);
+            }
+        }
+
+        for (const [noteTaskId, notes] of noteMap.entries()) {
+            // noteTaskId is from syncData (new ID). Find corresponding cache ID.
+            const taskId = reverseIdMap.get(noteTaskId) || noteTaskId;
             const mapping = taskFileMapping[taskId];
             if (!mapping) continue;
             if (mapping.syncEnabled === false) continue;
@@ -192,6 +211,22 @@ export class TodoistToObsidianSync {
             await this.plugin.cacheOperation!.updateTaskMappingSyncMeta(taskId, {
                 note_count: notes.length
             });
+        }
+    }
+
+    /**
+     * Resolve legacy numeric task IDs to new string IDs via the REST API
+     * ID mapping endpoint. Returns a map of oldId → newId for any IDs that
+     * were translated; non-legacy IDs are excluded.
+     */
+    private async resolveTaskIds(taskIds: string[]): Promise<Record<string, string>> {
+        const restApi = this.plugin.todoistRestAPI;
+        if (!restApi) return {};
+        try {
+            return await restApi.resolveIds('tasks', taskIds);
+        } catch (err) {
+            console.warn('[Todoist→Obsidian] Failed to resolve legacy task IDs, proceeding with original IDs:', err);
+            return {};
         }
     }
 

--- a/src/sync/toTodoist.ts
+++ b/src/sync/toTodoist.ts
@@ -47,9 +47,9 @@ export class ObsidianToTodoistSync {
         }
         const { cacheOperation, todoistSyncAPI } = this.requireServices();
         let file;
-        let currentFileValue;
+        let currentFileValue: string;
         let view;
-        let filepath;
+        let filepath: string;
         if (file_path) {
             file = this.app.vault.getAbstractFileByPath(file_path);
             file = this.requireTFile(file, 'deletedTaskCheck');
@@ -59,8 +59,8 @@ export class ObsidianToTodoistSync {
             view = this.app.workspace.getActiveViewOfType(MarkdownView);
             file = this.app.workspace.getActiveFile();
             file = this.requireTFile(file, 'deletedTaskCheck');
-            filepath = file?.path;
-            currentFileValue = view?.data;
+            filepath = file.path;
+            currentFileValue = view?.data ?? '';
         }
         const taskIds = cacheOperation.getTasksInFile(filepath);
         if (taskIds.length === 0) {
@@ -68,7 +68,7 @@ export class ObsidianToTodoistSync {
             return 0;
         }
 
-        const currentFileValueWithOutFrontMatter = currentFileValue.replace(/^---[\s\S]*?---\n/, '');
+        const currentFileValueWithOutFrontMatter = (currentFileValue ?? '').replace(/^---[\s\S]*?---\n/, '');
 
         const tasksToDelete = taskIds.filter(
             (taskId: string) =>
@@ -295,11 +295,11 @@ export class ObsidianToTodoistSync {
             this.plugin.debugLog('[toTodoist] Push blocked: not primary device');
             return;
         }
-        const { taskParser, cacheOperation, todoistSyncAPI, backupOperation } = this.requireServices();
+        const { taskParser, cacheOperation, todoistSyncAPI, backupOperation, fileOperation } = this.requireServices();
         let file;
-        let currentFileValue;
+        let currentFileValue: string;
         let view;
-        let filepath;
+        let filepath: string;
         if (file_path) {
             file = this.app.vault.getAbstractFileByPath(file_path);
             file = this.requireTFile(file, 'fullTextNewTaskCheck');
@@ -309,14 +309,14 @@ export class ObsidianToTodoistSync {
             view = this.app.workspace.getActiveViewOfType(MarkdownView);
             file = this.app.workspace.getActiveFile();
             file = this.requireTFile(file, 'fullTextNewTaskCheck');
-            filepath = file?.path;
-            currentFileValue = view?.data;
+            filepath = file.path;
+            currentFileValue = view?.data ?? '';
         }
         // Prevent per-task vault.modify from triggering modify event storm
         this.plugin.isProcessingModify = true;
         try {
         if (this.plugin.settings.enableFullVaultSync) {
-            await this.plugin.fileOperation.addTodoistTagToFile(filepath);
+            await fileOperation.addTodoistTagToFile(filepath);
             currentFileValue = await this.app.vault.read(file);
         }
 
@@ -343,7 +343,7 @@ export class ObsidianToTodoistSync {
                         this.plugin.logOperation?.log('OBSIDIAN_TASK_CREATED', `Created task in Obsidian: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
                         this.plugin.logOperation?.log('TODOIST_TASK_CREATED', `Created task in Todoist: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
 
-					await cacheOperation.setTaskFileMapping(todoist_id, filepath || '');
+					await cacheOperation.setTaskFileMapping(todoist_id!, filepath || '');
                     if (currentTask.isCompleted === true) {
                             await todoistSyncAPI.CloseTask(newTask.id);
                             this.plugin.logOperation?.log('OBSIDIAN_TASK_COMPLETED', `Completed task in Obsidian: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
@@ -363,9 +363,9 @@ export class ObsidianToTodoistSync {
 					}
                         try {
                             await todoistSyncAPI.incrementalSync();
-                            const updatedTask = await todoistSyncAPI.GetTaskById(todoist_id);
+                            const updatedTask = await todoistSyncAPI.GetTaskById(todoist_id!);
                             if (updatedTask?.updated_at) {
-                                await cacheOperation.updateTaskMappingSyncMeta(todoist_id, { updated_at: updatedTask.updated_at });
+                                await cacheOperation.updateTaskMappingSyncMeta(todoist_id!, { updated_at: updatedTask.updated_at });
                             }
                         } catch (syncErr) {
                             console.error('[fullTextNewTaskCheck] Post-push incremental sync failed:', syncErr);

--- a/src/sync/toTodoist.ts
+++ b/src/sync/toTodoist.ts
@@ -1,5 +1,5 @@
 import UltimateTodoistSyncForObsidian from "../../main";
-import { App, Editor, MarkdownView, Notice } from 'obsidian';
+import { App, Editor, MarkdownView, Notice, TFile } from 'obsidian';
 
 export class ObsidianToTodoistSync {
     app: App;
@@ -10,26 +10,59 @@ export class ObsidianToTodoistSync {
         this.plugin = plugin;
     }
 
+    private requireServices() {
+        const {
+            taskParser,
+            cacheOperation,
+            todoistSyncAPI,
+            fileOperation,
+            backupOperation,
+        } = this.plugin;
+
+        if (!taskParser || !cacheOperation || !todoistSyncAPI || !fileOperation) {
+            throw new Error('Todoist sync services are not initialized');
+        }
+
+        return {
+            taskParser,
+            cacheOperation,
+            todoistSyncAPI,
+            fileOperation,
+            backupOperation,
+        };
+    }
+
+    private requireTFile(file: unknown, context: string): TFile {
+        if (!(file instanceof TFile)) {
+            throw new Error(`${context}: target file not found`);
+        }
+
+        return file;
+    }
+
     async deletedTaskCheck(file_path: string): Promise<number> {
         if (!this.plugin.isPrimaryDevice()) {
             this.plugin.debugLog('[toTodoist] Push blocked: not primary device');
             return 0;
         }
+        const { cacheOperation, todoistSyncAPI } = this.requireServices();
         let file;
         let currentFileValue;
         let view;
         let filepath;
         if (file_path) {
             file = this.app.vault.getAbstractFileByPath(file_path);
+            file = this.requireTFile(file, 'deletedTaskCheck');
             filepath = file_path;
             currentFileValue = await this.app.vault.read(file);
         } else {
             view = this.app.workspace.getActiveViewOfType(MarkdownView);
             file = this.app.workspace.getActiveFile();
+            file = this.requireTFile(file, 'deletedTaskCheck');
             filepath = file?.path;
             currentFileValue = view?.data;
         }
-        const taskIds = this.plugin.cacheOperation.getTasksInFile(filepath);
+        const taskIds = cacheOperation.getTasksInFile(filepath);
         if (taskIds.length === 0) {
             this.plugin.debugLog('No tasks in this file');
             return 0;
@@ -40,18 +73,18 @@ export class ObsidianToTodoistSync {
         const tasksToDelete = taskIds.filter(
             (taskId: string) =>
                 !currentFileValueWithOutFrontMatter.includes(taskId) &&
-                this.plugin.cacheOperation.isTaskSyncEnabled(taskId)
+                cacheOperation.isTaskSyncEnabled(taskId)
         );
 
         let deletedCount = 0;
         for (const taskId of tasksToDelete) {
             try {
-                const api = this.plugin.todoistSyncAPI.initializeAPI();
+                const api = todoistSyncAPI.initializeAPI();
                 const response = await api.deleteTask(taskId);
                 if (response) {
                     new Notice(`task ${taskId} is deleted`);
                     this.plugin.logOperation?.log('OBSIDIAN_TASK_DELETED', `Deleted task: ${taskId}`, undefined, taskId);
-                    await this.plugin.cacheOperation.deleteTaskFileMapping(taskId);
+                    await cacheOperation.deleteTaskFileMapping(taskId);
                     deletedCount++;
                 }
             } catch (error) {
@@ -66,7 +99,7 @@ export class ObsidianToTodoistSync {
 				console.warn('[deletedTaskCheck] saveSettings skipped or failed');
 			}
 			try {
-				await this.plugin.todoistSyncAPI.incrementalSync();
+                await todoistSyncAPI.incrementalSync();
 			} catch (syncErr) {
 				console.error('[deletedTaskCheck] Post-push incremental sync failed:', syncErr);
             }
@@ -80,24 +113,25 @@ export class ObsidianToTodoistSync {
             this.plugin.debugLog('[toTodoist] Push blocked: not primary device');
             return;
         }
+        const { taskParser, cacheOperation, todoistSyncAPI } = this.requireServices();
         const filepath = view.file?.path;
         const fileContent = view?.data;
         const cursor = editor.getCursor();
         const line = cursor.line;
         const linetxt = editor.getLine(line);
 
-        const hasId = this.plugin.taskParser.hasTodoistId(linetxt);
-        const hasTag = this.plugin.taskParser.hasTodoistTag(linetxt);
+        const hasId = taskParser.hasTodoistId(linetxt);
+        const hasTag = taskParser.hasTodoistTag(linetxt);
         const isNewTask = !hasId && hasTag;
 
         if (isNewTask) {
-            const processedLine = hasTag ? linetxt : this.plugin.taskParser.addTodoistTag(linetxt);
+            const processedLine = hasTag ? linetxt : taskParser.addTodoistTag(linetxt);
             this.plugin.debugLog('this is a new task');
             this.plugin.debugLog(processedLine);
-            const currentTask = await this.plugin.taskParser.convertTextToTodoistTaskObject(processedLine, filepath, line, fileContent);
+            const currentTask = await taskParser.convertTextToTodoistTaskObject(processedLine, filepath, line, fileContent);
 
             try {
-                const newTask = await this.plugin.todoistSyncAPI.AddTask(currentTask);
+                const newTask = await todoistSyncAPI.AddTask(currentTask);
                 const { id: todoist_id } = newTask;
                 newTask.path = filepath;
                 new Notice(`new task ${newTask.content} id is ${newTask.id}`);
@@ -105,22 +139,22 @@ export class ObsidianToTodoistSync {
                 this.plugin.logOperation?.log('OBSIDIAN_TASK_CREATED', `Created task in Obsidian: ${newTask.content}`, filepath, todoist_id, 'obsidian→todoist');
                 this.plugin.logOperation?.log('TODOIST_TASK_CREATED', `Created task in Todoist: ${newTask.content}`, filepath, todoist_id, 'obsidian→todoist');
 
-				await this.plugin.cacheOperation.setTaskFileMapping(todoist_id, filepath || '');
+                await cacheOperation.setTaskFileMapping(todoist_id, filepath || '');
 
                 // Immediately sync so syncData contains the new task before any
                 // subsequent lineModifiedTaskCheck fires on the same line.
                 try {
-                    await this.plugin.todoistSyncAPI.incrementalSync();
-                    const updatedTask = await this.plugin.todoistSyncAPI.GetTaskById(todoist_id);
+                    await todoistSyncAPI.incrementalSync();
+                    const updatedTask = await todoistSyncAPI.GetTaskById(todoist_id);
                     if (updatedTask?.updated_at) {
-                        await this.plugin.cacheOperation.updateTaskMappingSyncMeta(todoist_id, { updated_at: updatedTask.updated_at });
+                        await cacheOperation.updateTaskMappingSyncMeta(todoist_id, { updated_at: updatedTask.updated_at });
                     }
                 } catch (syncErr) {
                     console.error('[lineContentNewTaskCheck] Post-create incremental sync failed:', syncErr);
                 }
 
                 if (currentTask.isCompleted === true) {
-                    await this.plugin.todoistSyncAPI.CloseTask(newTask.id);
+                    await todoistSyncAPI.CloseTask(newTask.id);
                     // taskFileMapping already set above
                     this.plugin.logOperation?.log('OBSIDIAN_TASK_COMPLETED', `Completed task in Obsidian: ${newTask.content}`, filepath, todoist_id, 'obsidian→todoist');
                     this.plugin.logOperation?.log('TODOIST_TASK_COMPLETED', `Completed task in Todoist: ${newTask.content}`, filepath, todoist_id, 'obsidian→todoist');
@@ -128,7 +162,7 @@ export class ObsidianToTodoistSync {
 
                 const text_with_out_link = `${processedLine} %%[todoist_id:: ${todoist_id}]%%`;
                 const link = this.plugin.settings.useAppURI ? `[link](todoist://task?id=${newTask.id})` : `[link](https://app.todoist.com/app/task/${newTask.id})`;
-                const text = this.plugin.taskParser.addTodoistLink(text_with_out_link, link);
+                const text = taskParser.addTodoistLink(text_with_out_link, link);
                 const from = { line: cursor.line, ch: 0 };
                 const to = { line: cursor.line, ch: linetxt.length };
                 try {
@@ -137,12 +171,12 @@ export class ObsidianToTodoistSync {
                     // replaceRange failed — roll back Todoist task to avoid duplicate on next trigger
                     console.error('[lineContentNewTaskCheck] replaceRange failed, rolling back Todoist task:', replaceError);
                     try {
-                        const api = this.plugin.todoistSyncAPI.initializeAPI();
+                        const api = todoistSyncAPI.initializeAPI();
                         await api.deleteTask(todoist_id);
                     } catch (deleteError) {
                         console.error('[lineContentNewTaskCheck] Rollback failed:', deleteError);
                     }
-                    await this.plugin.cacheOperation.deleteTaskFileMapping(todoist_id);
+                    await cacheOperation.deleteTaskFileMapping(todoist_id);
                     new Notice(`Failed to write task ID to file. Todoist task rolled back. Please try again.`);
                     return;
                 }
@@ -175,25 +209,26 @@ export class ObsidianToTodoistSync {
             this.plugin.debugLog('[lastLineNewTaskCheck] Push blocked: not primary device');
             return;
         }
+        const { taskParser, cacheOperation, todoistSyncAPI } = this.requireServices();
         if (!this.plugin.settings.enableFullVaultSync) return;
 
-        const isTask = this.plugin.taskParser.isMarkdownTask(lineText);
+        const isTask = taskParser.isMarkdownTask(lineText);
         if (!isTask) return;
 
-        const contentNotEmpty = this.plugin.taskParser.getTaskContentFromLineText(lineText) !== '';
+        const contentNotEmpty = taskParser.getTaskContentFromLineText(lineText) !== '';
         if (!contentNotEmpty) return;
 
-        const hasId = this.plugin.taskParser.hasTodoistId(lineText);
+        const hasId = taskParser.hasTodoistId(lineText);
         if (hasId) return;
 
-        const hasTag = this.plugin.taskParser.hasTodoistTag(lineText);
+        const hasTag = taskParser.hasTodoistTag(lineText);
         if (hasTag) return; // Already has #todoist — lineContentNewTaskCheck will handle it
 
         // Add #todoist tag
-        const processedLine = this.plugin.taskParser.addTodoistTag(lineText);
+        const processedLine = taskParser.addTodoistTag(lineText);
         this.plugin.debugLog('[lastLineNewTaskCheck] New task detected on line leave:', processedLine);
 
-        const currentTask = await this.plugin.taskParser.convertTextToTodoistTaskObject(processedLine, filepath, lineNumber, fileContent);
+        const currentTask = await taskParser.convertTextToTodoistTaskObject(processedLine, filepath, lineNumber, fileContent);
         if (typeof currentTask === 'undefined') {
             console.warn(`[lastLineNewTaskCheck] Task parser returned undefined for line: ${processedLine}`);
             this.plugin.debugLog(`[lastLineNewTaskCheck] Task parser returned undefined for line ${lineNumber} in ${filepath}`);
@@ -202,7 +237,7 @@ export class ObsidianToTodoistSync {
         }
 
         try {
-            const newTask = await this.plugin.todoistSyncAPI.AddTask(currentTask);
+            const newTask = await todoistSyncAPI.AddTask(currentTask);
             const { id: todoist_id } = newTask;
             newTask.path = filepath;
             new Notice(`new task ${newTask.content} id is ${newTask.id}`);
@@ -210,21 +245,21 @@ export class ObsidianToTodoistSync {
             this.plugin.logOperation?.log('OBSIDIAN_TASK_CREATED', `Created task in Obsidian: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
             this.plugin.logOperation?.log('TODOIST_TASK_CREATED', `Created task in Todoist: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
 
-            await this.plugin.cacheOperation.setTaskFileMapping(todoist_id, filepath || '');
+            await cacheOperation.setTaskFileMapping(todoist_id, filepath || '');
 
             // Immediately sync so syncData contains the new task
             try {
-                await this.plugin.todoistSyncAPI.incrementalSync();
-                const updatedTask = await this.plugin.todoistSyncAPI.GetTaskById(todoist_id);
+                await todoistSyncAPI.incrementalSync();
+                const updatedTask = await todoistSyncAPI.GetTaskById(todoist_id);
                 if (updatedTask?.updated_at) {
-                    await this.plugin.cacheOperation.updateTaskMappingSyncMeta(todoist_id, { updated_at: updatedTask.updated_at });
+                    await cacheOperation.updateTaskMappingSyncMeta(todoist_id, { updated_at: updatedTask.updated_at });
                 }
             } catch (syncErr) {
                 console.error('[lastLineNewTaskCheck] Post-create incremental sync failed:', syncErr);
             }
 
             if (currentTask.isCompleted === true) {
-                await this.plugin.todoistSyncAPI.CloseTask(newTask.id);
+                await todoistSyncAPI.CloseTask(newTask.id);
                 this.plugin.logOperation?.log('OBSIDIAN_TASK_COMPLETED', `Completed task in Obsidian: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
                 this.plugin.logOperation?.log('TODOIST_TASK_COMPLETED', `Completed task in Todoist: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
             }
@@ -232,19 +267,16 @@ export class ObsidianToTodoistSync {
             // Write tag + id + link back to the file
             const text_with_out_link = `${processedLine} %%[todoist_id:: ${todoist_id}]%%`;
             const link = this.plugin.settings.useAppURI ? `[link](todoist://task?id=${newTask.id})` : `[link](https://app.todoist.com/app/task/${newTask.id})`;
-            const text = this.plugin.taskParser.addTodoistLink(text_with_out_link, link);
+            const text = taskParser.addTodoistLink(text_with_out_link, link);
 
             // Use vault.read + vault.modify since cursor is no longer on this line
             const file = this.app.vault.getAbstractFileByPath(filepath);
-            if (!file) {
-                console.error(`[lastLineNewTaskCheck] File not found: ${filepath}`);
-                return;
-            }
-            const currentContent = await this.app.vault.read(file);
+            const taskFile = this.requireTFile(file, 'lastLineNewTaskCheck');
+            const currentContent = await this.app.vault.read(taskFile);
             const lines = currentContent.split('\n');
             if (lineNumber < lines.length) {
                 lines[lineNumber] = text;
-                await this.app.vault.modify(file, lines.join('\n'));
+                await this.app.vault.modify(taskFile, lines.join('\n'));
             }
 
             const saved = await this.plugin.saveSettings();
@@ -263,17 +295,20 @@ export class ObsidianToTodoistSync {
             this.plugin.debugLog('[toTodoist] Push blocked: not primary device');
             return;
         }
+        const { taskParser, cacheOperation, todoistSyncAPI, backupOperation } = this.requireServices();
         let file;
         let currentFileValue;
         let view;
         let filepath;
         if (file_path) {
             file = this.app.vault.getAbstractFileByPath(file_path);
+            file = this.requireTFile(file, 'fullTextNewTaskCheck');
             filepath = file_path;
             currentFileValue = await this.app.vault.read(file);
         } else {
             view = this.app.workspace.getActiveViewOfType(MarkdownView);
             file = this.app.workspace.getActiveFile();
+            file = this.requireTFile(file, 'fullTextNewTaskCheck');
             filepath = file?.path;
             currentFileValue = view?.data;
         }
@@ -288,9 +323,9 @@ export class ObsidianToTodoistSync {
             let lines = currentFileValue.split('\n');
         for (let i = 0; i < lines.length; i++) {
                 const line = lines[i];
-                if (!this.plugin.taskParser.hasTodoistId(line) && this.plugin.taskParser.hasTodoistTag(line)) {
+                if (!taskParser.hasTodoistId(line) && taskParser.hasTodoistTag(line)) {
                     this.plugin.debugLog(filepath);
-                    const currentTask = await this.plugin.taskParser.convertTextToTodoistTaskObject(line, filepath, i, lines.join('\n'));
+                    const currentTask = await taskParser.convertTextToTodoistTaskObject(line, filepath, i, lines.join('\n'));
                     if (typeof currentTask === 'undefined') {
                         console.warn(`[fullTextNewTaskCheck] Task parser returned undefined for line ${i} in ${filepath}`);
                         this.plugin.debugLog(`[fullTextNewTaskCheck] Task parser returned undefined for line ${i} in ${filepath}`);
@@ -300,7 +335,7 @@ export class ObsidianToTodoistSync {
                 this.plugin.debugLog(currentTask);
                     let todoist_id: string | undefined;
                     try {
-                        const newTask = await this.plugin.todoistSyncAPI.AddTask(currentTask);
+                        const newTask = await todoistSyncAPI.AddTask(currentTask);
                         todoist_id = newTask.id;
                         newTask.path = filepath;
                         this.plugin.debugLog(newTask);
@@ -308,29 +343,29 @@ export class ObsidianToTodoistSync {
                         this.plugin.logOperation?.log('OBSIDIAN_TASK_CREATED', `Created task in Obsidian: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
                         this.plugin.logOperation?.log('TODOIST_TASK_CREATED', `Created task in Todoist: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
 
-					await this.plugin.cacheOperation.setTaskFileMapping(todoist_id, filepath || '');
+					await cacheOperation.setTaskFileMapping(todoist_id, filepath || '');
                     if (currentTask.isCompleted === true) {
-                            await this.plugin.todoistSyncAPI.CloseTask(newTask.id);
+                            await todoistSyncAPI.CloseTask(newTask.id);
                             this.plugin.logOperation?.log('OBSIDIAN_TASK_COMPLETED', `Completed task in Obsidian: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
                             this.plugin.logOperation?.log('TODOIST_TASK_COMPLETED', `Completed task in Todoist: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
                         }
                     const text_with_out_link = `${line} %%[todoist_id:: ${todoist_id}]%%`;
                         const link = this.plugin.settings.useAppURI ? `[link](todoist://task?id=${newTask.id})` : `[link](https://app.todoist.com/app/task/${newTask.id})`;
-                        const text = this.plugin.taskParser.addTodoistLink(text_with_out_link, link);
+                        const text = taskParser.addTodoistLink(text_with_out_link, link);
                     lines[i] = text;
                         // Atomic: write file immediately after each task
                         const newContent = lines.join('\n');
-                        await this.plugin.backupOperation?.backupFile(filepath);
+                        await backupOperation?.backupFile(filepath);
                         await this.app.vault.modify(file, newContent);
 					const saved = await this.plugin.saveSettings();
 					if (!saved) {
 						console.warn('[fullTextNewTaskCheck] saveSettings skipped or failed');
 					}
                         try {
-                            await this.plugin.todoistSyncAPI.incrementalSync();
-                            const updatedTask = await this.plugin.todoistSyncAPI.GetTaskById(todoist_id);
+                            await todoistSyncAPI.incrementalSync();
+                            const updatedTask = await todoistSyncAPI.GetTaskById(todoist_id);
                             if (updatedTask?.updated_at) {
-                                await this.plugin.cacheOperation.updateTaskMappingSyncMeta(todoist_id, { updated_at: updatedTask.updated_at });
+                                await cacheOperation.updateTaskMappingSyncMeta(todoist_id, { updated_at: updatedTask.updated_at });
                             }
                         } catch (syncErr) {
                             console.error('[fullTextNewTaskCheck] Post-push incremental sync failed:', syncErr);
@@ -345,11 +380,11 @@ export class ObsidianToTodoistSync {
                         // Rollback: delete Todoist task + clean mapping if we got an id
                         if (todoist_id) {
                             try {
-                                await this.plugin.todoistSyncAPI.deleteTask(todoist_id);
+                                await todoistSyncAPI.deleteTask(todoist_id);
                             } catch (deleteError) {
                                 console.error('[fullTextNewTaskCheck] Rollback deleteTask failed:', deleteError);
                             }
-                            await this.plugin.cacheOperation.deleteTaskFileMapping(todoist_id);
+                            await cacheOperation.deleteTaskFileMapping(todoist_id);
                         }
                         continue;
                     }
@@ -365,25 +400,29 @@ export class ObsidianToTodoistSync {
             this.plugin.debugLog('[toTodoist] Push blocked: not primary device');
             return;
         }
-        if (this.plugin.taskParser.hasTodoistId(lineText) && this.plugin.taskParser.hasTodoistTag(lineText)) {
-            const lineTask = await this.plugin.taskParser.convertTextToTodoistTaskObject(lineText, filepath, lineNumber, fileContent);
-            const lineTask_todoist_id = (lineTask.todoist_id).toString();
+        const { taskParser, cacheOperation, todoistSyncAPI } = this.requireServices();
+        if (taskParser.hasTodoistId(lineText) && taskParser.hasTodoistTag(lineText)) {
+            const lineTask = await taskParser.convertTextToTodoistTaskObject(lineText, filepath, lineNumber, fileContent);
+            if (!lineTask || !lineTask.todoist_id) {
+                return;
+            }
+            const lineTask_todoist_id = lineTask.todoist_id.toString();
 
-            const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(lineTask_todoist_id);
+            const taskMapping = cacheOperation.getTaskFileMapping(lineTask_todoist_id);
             if (!taskMapping) {
                 this.plugin.debugLog(`Local cache has no task ${lineTask.todoist_id}`);
-                const url = this.plugin.taskParser.getObsidianUrlFromFilepath(filepath);
+                const url = taskParser.getObsidianUrlFromFilepath(filepath);
                 this.plugin.debugLog(url);
                 return;
             }
 
-            if (!this.plugin.cacheOperation.isTaskSyncEnabled(lineTask_todoist_id)) {
+            if (!cacheOperation.isTaskSyncEnabled(lineTask_todoist_id)) {
                 this.plugin.debugLog(`[lineModifiedTaskCheck] Sync disabled for task ${lineTask_todoist_id}, skipping modification`);
                 this.plugin.logOperation?.log('SYNC_DISABLED_SKIP', `User edit ignored: sync disabled for task ${lineTask_todoist_id}`, filepath, lineTask_todoist_id);
                 return;
             }
 
-            const savedTask = await this.plugin.todoistSyncAPI.GetTaskById(lineTask_todoist_id);
+            const savedTask = await todoistSyncAPI.GetTaskById(lineTask_todoist_id);
 
             // Handle deleted task: task exists in cache but not in Todoist
             if (!savedTask) {
@@ -398,8 +437,8 @@ export class ObsidianToTodoistSync {
                     return;
                 }
                 console.warn(`[lineModifiedTaskCheck] Task ${lineTask_todoist_id} not found in Todoist (deleted?), marking as issue`);
-                await this.plugin.cacheOperation.setTaskFileMapping(lineTask_todoist_id, taskMapping.filePath, 'issue', false);
-				await this.plugin.cacheOperation.upsertTaskIssue(lineTask_todoist_id, 'todoist_task_missing', {
+                await cacheOperation.setTaskFileMapping(lineTask_todoist_id, taskMapping.filePath, 'issue', false);
+				await cacheOperation.upsertTaskIssue(lineTask_todoist_id, 'todoist_task_missing', {
                     state: 'open',
                     severity: 'high',
                     source: 'runtime',
@@ -419,29 +458,29 @@ export class ObsidianToTodoistSync {
 
                 if (strategy === 'todoist-wins') {
                     // Let toObsidian pull overwrite Obsidian on next sync — just update cached updated_at
-                    await this.plugin.cacheOperation.updateTaskMappingSyncMeta(lineTask_todoist_id, { updated_at: undefined });
+                    await cacheOperation.updateTaskMappingSyncMeta(lineTask_todoist_id, { updated_at: undefined });
                     new Notice(`Conflict on task ${lineTask_todoist_id}: Todoist wins — Obsidian will be updated on next sync.`);
                     return;
                 } else if (strategy === 'obsidian-wins') {
                     // Force-update Todoist with Obsidian content — fall through to normal update logic below
                     new Notice(`Conflict on task ${lineTask_todoist_id}: Obsidian wins — pushing to Todoist.`);
                     // Reset cached updated_at so toObsidian won't overwrite back
-                    await this.plugin.cacheOperation.updateTaskMappingSyncMeta(lineTask_todoist_id, { updated_at: savedTask.updated_at });
+                    await cacheOperation.updateTaskMappingSyncMeta(lineTask_todoist_id, { updated_at: savedTask.updated_at });
                     // fall through
                 } else {
                     // manual: disable sync until user resolves
-                    await this.plugin.cacheOperation.setTaskFileMapping(lineTask_todoist_id, taskMapping.filePath, 'conflicted', false);
+                    await cacheOperation.setTaskFileMapping(lineTask_todoist_id, taskMapping.filePath, 'conflicted', false);
                     new Notice(`Task ${lineTask_todoist_id} has a conflict: modified in both Obsidian and Todoist. Sync disabled until resolved.`);
                     return;
                 }
             }
 
             const lineTaskContent = lineTask.content;
-            const contentModified = !this.plugin.taskParser.taskContentCompare(lineTask, savedTask);
-            const tagsModified = !this.plugin.taskParser.taskTagCompare(lineTask, savedTask);
-            const statusModified = !this.plugin.taskParser.taskStatusCompare(lineTask, savedTask);
-            const dueDateModified = !this.plugin.taskParser.compareTaskDueDate(lineTask, savedTask);
-            const priorityModified = !this.plugin.taskParser.taskPriorityCompare(lineTask, savedTask);
+            const contentModified = !taskParser.taskContentCompare(lineTask, savedTask);
+            const tagsModified = !taskParser.taskTagCompare(lineTask, savedTask);
+            const statusModified = !taskParser.taskStatusCompare(lineTask, savedTask);
+            const dueDateModified = !taskParser.compareTaskDueDate(lineTask, savedTask);
+            const priorityModified = !taskParser.taskPriorityCompare(lineTask, savedTask);
 
             try {
                 let contentChanged = false;
@@ -480,7 +519,7 @@ export class ObsidianToTodoistSync {
                 }
 
                 if (contentChanged || tagsChanged || dueDateChanged || priorityChanged) {
-                    const updatedTask = await this.plugin.todoistSyncAPI.UpdateTask(lineTask.todoist_id.toString(), updatedContent);
+                    const updatedTask = await todoistSyncAPI.UpdateTask(lineTask_todoist_id, updatedContent);
                     // taskFileMapping already set, no need to update
                     this.plugin.logOperation?.log('OBSIDIAN_TASK_MODIFIED', `Updated task: ${updatedTask.content}`, filepath, lineTask_todoist_id, 'obsidian→todoist');
                     this.plugin.logOperation?.log('TODOIST_TASK_UPDATED', `Updated task in Todoist: ${updatedTask.content}`, filepath, lineTask_todoist_id, 'obsidian→todoist');
@@ -490,13 +529,13 @@ export class ObsidianToTodoistSync {
                     this.plugin.debugLog(`Status modified for task ${lineTask_todoist_id}`);
                     if (lineTask.isCompleted === true) {
                         this.plugin.debugLog(`task completed`);
-                        await this.plugin.todoistSyncAPI.CloseTask(lineTask.todoist_id.toString());
+                        await todoistSyncAPI.CloseTask(lineTask_todoist_id);
                         // taskFileMapping already set, no need to update
                         this.plugin.logOperation?.log('OBSIDIAN_TASK_COMPLETED', `Completed task: ${lineTask.content}`, filepath, lineTask_todoist_id, 'obsidian→todoist');
                         this.plugin.logOperation?.log('TODOIST_TASK_COMPLETED', `Completed task in Todoist: ${lineTask.content}`, filepath, lineTask_todoist_id, 'obsidian→todoist');
                     } else {
                         this.plugin.debugLog(`task uncompleted`);
-                        await this.plugin.todoistSyncAPI.OpenTask(lineTask.todoist_id.toString());
+                        await todoistSyncAPI.OpenTask(lineTask_todoist_id);
                         // taskFileMapping already set, no need to update
                         this.plugin.logOperation?.log('OBSIDIAN_TASK_REOPENED', `Reopened task: ${lineTask.content}`, filepath, lineTask_todoist_id);
                         this.plugin.logOperation?.log('TODOIST_TASK_REOPENED', `Reopened task in Todoist: ${lineTask.content}`, filepath, lineTask_todoist_id, 'obsidian→todoist');
@@ -512,10 +551,10 @@ export class ObsidianToTodoistSync {
 						console.warn('[lineModifiedTaskCheck] saveSettings skipped or failed');
 					}
                     try {
-                        await this.plugin.todoistSyncAPI.incrementalSync();
-                        const refreshedTask = await this.plugin.todoistSyncAPI.GetTaskById(lineTask_todoist_id);
+                        await todoistSyncAPI.incrementalSync();
+                        const refreshedTask = await todoistSyncAPI.GetTaskById(lineTask_todoist_id);
                         if (refreshedTask?.updated_at) {
-                            await this.plugin.cacheOperation.updateTaskMappingSyncMeta(lineTask_todoist_id, { updated_at: refreshedTask.updated_at });
+                            await cacheOperation.updateTaskMappingSyncMeta(lineTask_todoist_id, { updated_at: refreshedTask.updated_at });
                         }
                     } catch (syncErr) {
                         console.error('[lineModifiedTaskCheck] Post-push incremental sync failed:', syncErr);
@@ -549,6 +588,7 @@ export class ObsidianToTodoistSync {
     }
 
     async fullTextModifiedTaskCheck(file_path: string): Promise<void> {
+        const { taskParser } = this.requireServices();
         let file;
         let currentFileValue;
         let view;
@@ -557,21 +597,23 @@ export class ObsidianToTodoistSync {
         try {
             if (file_path) {
                 file = this.app.vault.getAbstractFileByPath(file_path);
+                file = this.requireTFile(file, 'fullTextModifiedTaskCheck');
                 filepath = file_path;
                 currentFileValue = await this.app.vault.read(file);
             } else {
                 view = this.app.workspace.getActiveViewOfType(MarkdownView);
                 file = this.app.workspace.getActiveFile();
+                file = this.requireTFile(file, 'fullTextModifiedTaskCheck');
                 filepath = file?.path;
                 currentFileValue = view?.data;
             }
 
-            const content = currentFileValue;
+            const content = currentFileValue ?? '';
             const lines = content.split('\n');
 
             for (let i = 0; i < lines.length; i++) {
                 const line = lines[i];
-                if (this.plugin.taskParser.hasTodoistId(line) && this.plugin.taskParser.hasTodoistTag(line)) {
+                if (taskParser.hasTodoistId(line) && taskParser.hasTodoistTag(line)) {
                     try {
                         await this.lineModifiedTaskCheck(filepath, line, i, content);
                     } catch (error) {
@@ -590,18 +632,19 @@ export class ObsidianToTodoistSync {
             this.plugin.debugLog('[toTodoist] Push blocked: not primary device');
             return;
         }
-        if (!this.plugin.cacheOperation?.isTaskSyncEnabled(taskId)) {
+        const { cacheOperation, todoistSyncAPI, fileOperation } = this.requireServices();
+        if (!cacheOperation.isTaskSyncEnabled(taskId)) {
             this.plugin.debugLog(`[closeTask] Sync disabled for task ${taskId}, skipping close`);
             this.plugin.logOperation?.log('SYNC_DISABLED_SKIP', `Checkbox close ignored: sync disabled for task ${taskId}`, undefined, taskId);
             return;
         }
         try {
-            const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId);
-            const savedTask = await this.plugin.todoistSyncAPI.GetTaskById(taskId);
+            const taskMapping = cacheOperation.getTaskFileMapping(taskId);
+            const savedTask = await todoistSyncAPI.GetTaskById(taskId);
 
             if (!savedTask) {
-                await this.plugin.cacheOperation.setTaskFileMapping(taskId, taskMapping?.filePath || '', 'issue', false);
-				await this.plugin.cacheOperation.upsertTaskIssue(taskId, 'todoist_task_missing', {
+                await cacheOperation.setTaskFileMapping(taskId, taskMapping?.filePath || '', 'issue', false);
+				await cacheOperation.upsertTaskIssue(taskId, 'todoist_task_missing', {
                     state: 'open',
                     severity: 'high',
                     source: 'runtime',
@@ -616,28 +659,28 @@ export class ObsidianToTodoistSync {
                 const strategy = this.plugin.settings.conflictResolutionStrategy;
                 this.plugin.logOperation?.log('CONFLICT_DETECTED', `Conflict on closeTask ${taskId} (strategy: ${strategy})`, undefined, taskId);
                 if (strategy === 'todoist-wins') {
-                    await this.plugin.cacheOperation.updateTaskMappingSyncMeta(taskId, { updated_at: undefined });
+                    await cacheOperation.updateTaskMappingSyncMeta(taskId, { updated_at: undefined });
                     new Notice(`Conflict on task ${taskId}: Todoist wins — Obsidian will be updated on next sync.`);
                     return;
                 } else if (strategy === 'manual') {
-                    await this.plugin.cacheOperation.setTaskFileMapping(taskId, taskMapping.filePath, 'conflicted', false);
+                    await cacheOperation.setTaskFileMapping(taskId, taskMapping.filePath, 'conflicted', false);
                     new Notice(`Task ${taskId} has a conflict. Sync disabled until resolved.`);
                     return;
                 }
                 // obsidian-wins: fall through and close
             }
 
-            await this.plugin.todoistSyncAPI.CloseTask(taskId);
-			await this.plugin.fileOperation.completeTaskInTheFile(taskId);
+            await todoistSyncAPI.CloseTask(taskId);
+			await fileOperation.completeTaskInTheFile(taskId);
 			const saved = await this.plugin.saveSettings();
 			if (!saved) {
 				console.warn('[closeTask] saveSettings skipped or failed');
 			}
             try {
-                await this.plugin.todoistSyncAPI.incrementalSync();
-                const refreshedTask = await this.plugin.todoistSyncAPI.GetTaskById(taskId);
+                await todoistSyncAPI.incrementalSync();
+                const refreshedTask = await todoistSyncAPI.GetTaskById(taskId);
                 if (refreshedTask?.updated_at) {
-                    await this.plugin.cacheOperation.updateTaskMappingSyncMeta(taskId, { updated_at: refreshedTask.updated_at });
+                    await cacheOperation.updateTaskMappingSyncMeta(taskId, { updated_at: refreshedTask.updated_at });
                 }
             } catch (syncErr) {
                 console.error('[closeTask] Post-push incremental sync failed:', syncErr);
@@ -655,18 +698,19 @@ export class ObsidianToTodoistSync {
             this.plugin.debugLog('[toTodoist] Push blocked: not primary device');
             return;
         }
-        if (!this.plugin.cacheOperation?.isTaskSyncEnabled(taskId)) {
+        const { cacheOperation, todoistSyncAPI, fileOperation } = this.requireServices();
+        if (!cacheOperation.isTaskSyncEnabled(taskId)) {
             this.plugin.debugLog(`[repoenTask] Sync disabled for task ${taskId}, skipping reopen`);
             this.plugin.logOperation?.log('SYNC_DISABLED_SKIP', `Checkbox reopen ignored: sync disabled for task ${taskId}`, undefined, taskId);
             return;
         }
         try {
-            const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId);
-            const savedTask = await this.plugin.todoistSyncAPI.GetTaskById(taskId);
+            const taskMapping = cacheOperation.getTaskFileMapping(taskId);
+            const savedTask = await todoistSyncAPI.GetTaskById(taskId);
 
             if (!savedTask) {
-                await this.plugin.cacheOperation.setTaskFileMapping(taskId, taskMapping?.filePath || '', 'issue', false);
-				await this.plugin.cacheOperation.upsertTaskIssue(taskId, 'todoist_task_missing', {
+                await cacheOperation.setTaskFileMapping(taskId, taskMapping?.filePath || '', 'issue', false);
+				await cacheOperation.upsertTaskIssue(taskId, 'todoist_task_missing', {
                     state: 'open',
                     severity: 'high',
                     source: 'runtime',
@@ -681,28 +725,28 @@ export class ObsidianToTodoistSync {
                 const strategy = this.plugin.settings.conflictResolutionStrategy;
                 this.plugin.logOperation?.log('CONFLICT_DETECTED', `Conflict on repoenTask ${taskId} (strategy: ${strategy})`, undefined, taskId);
                 if (strategy === 'todoist-wins') {
-                    await this.plugin.cacheOperation.updateTaskMappingSyncMeta(taskId, { updated_at: undefined });
+                    await cacheOperation.updateTaskMappingSyncMeta(taskId, { updated_at: undefined });
                     new Notice(`Conflict on task ${taskId}: Todoist wins — Obsidian will be updated on next sync.`);
                     return;
                 } else if (strategy === 'manual') {
-                    await this.plugin.cacheOperation.setTaskFileMapping(taskId, taskMapping.filePath, 'conflicted', false);
+                    await cacheOperation.setTaskFileMapping(taskId, taskMapping.filePath, 'conflicted', false);
                     new Notice(`Task ${taskId} has a conflict. Sync disabled until resolved.`);
                     return;
                 }
                 // obsidian-wins: fall through and reopen
             }
 
-            await this.plugin.todoistSyncAPI.OpenTask(taskId);
-			await this.plugin.fileOperation.uncompleteTaskInTheFile(taskId);
+            await todoistSyncAPI.OpenTask(taskId);
+			await fileOperation.uncompleteTaskInTheFile(taskId);
 			const saved = await this.plugin.saveSettings();
 			if (!saved) {
 				console.warn('[repoenTask] saveSettings skipped or failed');
 			}
             try {
-                await this.plugin.todoistSyncAPI.incrementalSync();
-                const refreshedTask = await this.plugin.todoistSyncAPI.GetTaskById(taskId);
+                await todoistSyncAPI.incrementalSync();
+                const refreshedTask = await todoistSyncAPI.GetTaskById(taskId);
                 if (refreshedTask?.updated_at) {
-                    await this.plugin.cacheOperation.updateTaskMappingSyncMeta(taskId, { updated_at: refreshedTask.updated_at });
+                    await cacheOperation.updateTaskMappingSyncMeta(taskId, { updated_at: refreshedTask.updated_at });
                 }
             } catch (syncErr) {
                 console.error('[repoenTask] Post-push incremental sync failed:', syncErr);
@@ -718,7 +762,8 @@ export class ObsidianToTodoistSync {
 
 
     async updateTaskDescription(filepath: string): Promise<void> {
-        const taskIds = this.plugin.cacheOperation.getTasksInFile(filepath);
+        const { cacheOperation, taskParser, todoistSyncAPI } = this.requireServices();
+        const taskIds = cacheOperation.getTasksInFile(filepath);
 
         if (taskIds.length === 0) {
             return;
@@ -726,16 +771,16 @@ export class ObsidianToTodoistSync {
 
         for (const taskId of taskIds) {
             try {
-                const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId);
+                const taskMapping = cacheOperation.getTaskFileMapping(taskId);
                 if (taskMapping) {
-                    if (!this.plugin.cacheOperation.isTaskSyncEnabled(taskId)) continue;
-                    const description = this.plugin.taskParser.getObsidianUrlFromFilepath(filepath);
-                    const todoistTask = await this.plugin.todoistSyncAPI.GetTaskById(taskId);
+                    if (!cacheOperation.isTaskSyncEnabled(taskId)) continue;
+                    const description = taskParser.getObsidianUrlFromFilepath(filepath);
+                    const todoistTask = await todoistSyncAPI.GetTaskById(taskId);
                     if (todoistTask?.description === description) {
                         continue;
                     }
 
-                    await this.plugin.todoistSyncAPI.UpdateTask(taskId, { description });
+                    await todoistSyncAPI.UpdateTask(taskId, { description });
                     this.plugin.logOperation?.log('TODOIST_TASK_UPDATED', `Updated task description: ${taskId}`, filepath, taskId, 'obsidian→todoist');
                 }
             } catch (error) {

--- a/src/vault/fileOperation.ts
+++ b/src/vault/fileOperation.ts
@@ -128,7 +128,7 @@ export class FileOperation   {
      // 完成一个任务，将其标记为已完成
     async completeTaskInTheFile(taskId: string) {
         // 获取任务文件路径
-        const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId)
+        const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId)
         if (!taskMapping) {
             console.error(`Task ${taskId} not found in taskFileMapping`);
             return;
@@ -144,7 +144,7 @@ export class FileOperation   {
     
         for (let i = 0; i < lines.length; i++) {
         const line = lines[i]
-        if (line.includes(taskId) && this.plugin.taskParser.hasTodoistTag(line)) {
+        if (line.includes(taskId) && this.plugin.taskParser!.hasTodoistTag(line)) {
             lines[i] = line.replace('[ ]', '[x]')
             modified = true
             break
@@ -162,7 +162,7 @@ export class FileOperation   {
     // uncheck 已完成的任务，
     async uncompleteTaskInTheFile(taskId: string) {
         // 获取任务文件路径
-        const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId)
+        const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId)
         if (!taskMapping) {
             console.error(`Task ${taskId} not found in taskFileMapping`);
             return;
@@ -178,7 +178,7 @@ export class FileOperation   {
     
         for (let i = 0; i < lines.length; i++) {
         const line = lines[i]
-        if (line.includes(taskId) && this.plugin.taskParser.hasTodoistTag(line)) {
+        if (line.includes(taskId) && this.plugin.taskParser!.hasTodoistTag(line)) {
             lines[i] = line.replace(/- \[(x|X)\]/g, '- [ ]');
             modified = true
             break
@@ -198,7 +198,7 @@ export class FileOperation   {
      * The task line remains in the file but is no longer associated with Todoist.
      */
     async unbindTaskInFile(taskId: string): Promise<void> {
-        const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId);
+        const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId);
         if (!taskMapping) {
             console.error(`[FileOperation] unbindTaskInFile: Task ${taskId} not found in taskFileMapping`);
             return;
@@ -246,20 +246,20 @@ export class FileOperation   {
     
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i]
-            if(!this.plugin.taskParser.isMarkdownTask(line)){
+            if(!this.plugin.taskParser!.isMarkdownTask(line)){
                 //this.plugin.debugLog(line)
                 //this.plugin.debugLog("It is not a markdown task.")
                 continue;
             }
             //if content is empty
-            if(this.plugin.taskParser.getTaskContentFromLineText(line) == ""){
+            if(this.plugin.taskParser!.getTaskContentFromLineText(line) == ""){
                 //this.plugin.debugLog("Line content is empty")
                 continue;
             }
-            if (!this.plugin.taskParser.hasTodoistId(line) && !this.plugin.taskParser.hasTodoistTag(line)) {
+            if (!this.plugin.taskParser!.hasTodoistId(line) && !this.plugin.taskParser!.hasTodoistTag(line)) {
                 //this.plugin.debugLog(line)
                 //this.plugin.debugLog('prepare to add todoist tag')
-                const newLine = this.plugin.taskParser.addTodoistTag(line);
+                const newLine = this.plugin.taskParser!.addTodoistTag(line);
                 //this.plugin.debugLog(newLine)
                 lines[i] = newLine
                 modified = true
@@ -290,24 +290,24 @@ export class FileOperation   {
     
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i]
-            if (this.plugin.taskParser.hasTodoistId(line) && this.plugin.taskParser.hasTodoistTag(line)) {
-                if(this.plugin.taskParser.hasTodoistLink(line)){
+            if (this.plugin.taskParser!.hasTodoistId(line) && this.plugin.taskParser!.hasTodoistTag(line)) {
+                if(this.plugin.taskParser!.hasTodoistLink(line)){
                     return
                 }
                 this.plugin.debugLog(line)
                 //this.plugin.debugLog('prepare to add todoist link')
-                const taskID = this.plugin.taskParser.getTodoistIdFromLineText(line)
-                const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskID)
+                const taskID = this.plugin.taskParser!.getTodoistIdFromLineText(line)
+                const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskID ?? '')
                 if (!taskMapping) {
                     console.error(`Task ${taskID} not found in taskFileMapping`);
                     continue;
                 }
-                await this.plugin.todoistSyncAPI.GetTaskById(taskID)
+                await this.plugin.todoistSyncAPI!.GetTaskById(taskID ?? '')
                 const todoistLink = this.plugin.settings.useAppURI
                     ? `todoist://task?id=${taskID}`
                     : `https://app.todoist.com/app/task/${taskID}`
                 const link = `[link](${todoistLink})`
-                const newLine = this.plugin.taskParser.addTodoistLink(line,link)
+                const newLine = this.plugin.taskParser!.addTodoistLink(line,link)
                 this.plugin.debugLog(newLine)
                 lines[i] = newLine
                 modified = true
@@ -332,7 +332,7 @@ export class FileOperation   {
     async syncUpdatedTaskContentToTheFile(evt:any) {
         const taskId = evt.object_id
         // 获取任务文件路径
-        const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId)
+        const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId)
         if (!taskMapping) {
             console.error(`Task ${taskId} not found in taskFileMapping`);
             return;
@@ -348,8 +348,8 @@ export class FileOperation   {
     
         for (let i = 0; i < lines.length; i++) {
         const line = lines[i]
-        if (line.includes(taskId) && this.plugin.taskParser.hasTodoistTag(line)) {
-            const oldTaskContent = this.plugin.taskParser.getTaskContentFromLineText(line)
+        if (line.includes(taskId) && this.plugin.taskParser!.hasTodoistTag(line)) {
+            const oldTaskContent = this.plugin.taskParser!.getTaskContentFromLineText(line)
             const newTaskContent = evt.extra_data.content
 
             lines[i] = line.replace(oldTaskContent, newTaskContent)
@@ -372,7 +372,7 @@ export class FileOperation   {
     async syncUpdatedTaskDueDateToTheFile(evt:any) {
         const taskId = evt.object_id
         // 获取任务文件路径
-        const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId)
+        const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId)
         if (!taskMapping) {
             console.error(`Task ${taskId} not found in taskFileMapping`);
             return;
@@ -388,16 +388,16 @@ export class FileOperation   {
     
         for (let i = 0; i < lines.length; i++) {
         const line = lines[i]
-        if (line.includes(taskId) && this.plugin.taskParser.hasTodoistTag(line)) {
-            const oldTaskDueDate = this.plugin.taskParser.getDueDateFromLineText(line) || ""
-            const newTaskDueDate = this.plugin.taskParser.ISOStringToLocalDateString(evt.extra_data.due_date) || ""
+        if (line.includes(taskId) && this.plugin.taskParser!.hasTodoistTag(line)) {
+            const oldTaskDueDate = this.plugin.taskParser!.getDueDateFromLineText(line) || ""
+            const newTaskDueDate = this.plugin.taskParser!.ISOStringToLocalDateString(evt.extra_data.due_date) || ""
             
             //this.plugin.debugLog(`${taskId} duedate is updated`)
             this.plugin.debugLog(oldTaskDueDate)
             this.plugin.debugLog(newTaskDueDate)
             if(oldTaskDueDate === ""){
-                //this.plugin.debugLog(this.plugin.taskParser.insertDueDateBeforeTodoist(line,newTaskDueDate))
-                lines[i] = this.plugin.taskParser.insertDueDateBeforeTodoist(line,newTaskDueDate)
+                //this.plugin.debugLog(this.plugin.taskParser!.insertDueDateBeforeTodoist(line,newTaskDueDate))
+                lines[i] = this.plugin.taskParser!.insertDueDateBeforeTodoist(line,newTaskDueDate)
                 modified = true
 
             }
@@ -433,9 +433,9 @@ export class FileOperation   {
 
         const taskId = evt.parent_item_id
         const note = evt.extra_data.content
-        const datetime = this.plugin.taskParser.ISOStringToLocalDatetimeString(evt.event_date)
+        const datetime = this.plugin.taskParser!.ISOStringToLocalDatetimeString(evt.event_date)
         // 获取任务文件路径
-        const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId)
+        const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId)
         if (!taskMapping) {
             console.error(`Task ${taskId} not found in taskFileMapping`);
             return;
@@ -451,7 +451,7 @@ export class FileOperation   {
     
         for (let i = 0; i < lines.length; i++) {
         const line = lines[i]
-        if (line.includes(taskId) && this.plugin.taskParser.hasTodoistTag(line)) {
+        if (line.includes(taskId) && this.plugin.taskParser!.hasTodoistTag(line)) {
             const indent = '\t'.repeat(line.length - line.trimStart().length + 1);
             const noteLine = `${indent}- ${datetime} ${note}`;
             lines.splice(i + 1, 0, noteLine);
@@ -472,7 +472,7 @@ export class FileOperation   {
 
 
     async syncTaskContentToFile(taskId: string, newContent: string): Promise<boolean> {
-        const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId);
+        const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId);
         if (!taskMapping) return false;
         const filepath = taskMapping.filePath;
 
@@ -483,8 +483,8 @@ export class FileOperation   {
 
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i];
-            if (line.includes(taskId) && this.plugin.taskParser.hasTodoistTag(line)) {
-                const oldContent = this.plugin.taskParser.getTaskContentFromLineText(line);
+            if (line.includes(taskId) && this.plugin.taskParser!.hasTodoistTag(line)) {
+                const oldContent = this.plugin.taskParser!.getTaskContentFromLineText(line);
                 if (oldContent && oldContent !== newContent) {
                     lines[i] = line.replace(oldContent, newContent);
                     modified = true;
@@ -503,7 +503,7 @@ export class FileOperation   {
     }
 
     async syncTaskDueDateToFile(taskId: string, newDueDate: string): Promise<boolean> {
-        const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId);
+        const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId);
         if (!taskMapping) return false;
         const filepath = taskMapping.filePath;
 
@@ -514,14 +514,14 @@ export class FileOperation   {
 
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i];
-            if (line.includes(taskId) && this.plugin.taskParser.hasTodoistTag(line)) {
-                const oldDueDate = this.plugin.taskParser.getDueDateFromLineText(line) || "";
-                const localDueDate = this.plugin.taskParser.ISOStringToLocalDateString(newDueDate) || "";
+            if (line.includes(taskId) && this.plugin.taskParser!.hasTodoistTag(line)) {
+                const oldDueDate = this.plugin.taskParser!.getDueDateFromLineText(line) || "";
+                const localDueDate = this.plugin.taskParser!.ISOStringToLocalDateString(newDueDate) || "";
 
                 if (oldDueDate === localDueDate) break;
 
                 if (oldDueDate === "" && localDueDate !== "") {
-                    lines[i] = this.plugin.taskParser.insertDueDateBeforeTodoist(line, localDueDate);
+                    lines[i] = this.plugin.taskParser!.insertDueDateBeforeTodoist(line, localDueDate);
                     modified = true;
                 } else if (localDueDate === "") {
                     const regexRemoveDate = /(🗓️|📅|📆|🗓)\s?\d{4}-\d{2}-\d{2}/;
@@ -553,7 +553,7 @@ export class FileOperation   {
     }
 
     async syncTaskPriorityToFile(taskId: string, newPriority: number): Promise<boolean> {
-        const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId);
+        const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId);
         if (!taskMapping) return false;
         const filepath = taskMapping.filePath;
 
@@ -569,9 +569,9 @@ export class FileOperation   {
 
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i];
-            if (!line.includes(taskId) || !this.plugin.taskParser.hasTodoistTag(line)) continue;
+            if (!line.includes(taskId) || !this.plugin.taskParser!.hasTodoistTag(line)) continue;
 
-            const currentPriority = this.plugin.taskParser.getTaskPriority(line);
+            const currentPriority = this.plugin.taskParser!.getTaskPriority(line);
             if (currentPriority === targetPriority) break;
 
             const metadataIndex = line.indexOf('%%[todoist_id::');
@@ -598,7 +598,7 @@ export class FileOperation   {
     }
 
     async syncTaskLabelsToFile(taskId: string, newLabels: string[]): Promise<boolean> {
-        const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId);
+        const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId);
         if (!taskMapping) return false;
         const filepath = taskMapping.filePath;
 
@@ -608,14 +608,14 @@ export class FileOperation   {
         let modified = false;
 
         const todoistLabels = this.normalizeLabelsForSync(newLabels);
-        const desiredLabels = this.plugin.taskParser.normalizeLabelsForCompare([...todoistLabels, 'todoist']);
+        const desiredLabels = this.plugin.taskParser!.normalizeLabelsForCompare([...todoistLabels, 'todoist']);
 
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i];
-            if (!line.includes(taskId) || !this.plugin.taskParser.hasTodoistTag(line)) continue;
+            if (!line.includes(taskId) || !this.plugin.taskParser!.hasTodoistTag(line)) continue;
 
-            const currentLabels = this.plugin.taskParser.normalizeLabelsForCompare(
-                this.plugin.taskParser.getAllTagsFromLineText(line)
+            const currentLabels = this.plugin.taskParser!.normalizeLabelsForCompare(
+                this.plugin.taskParser!.getAllTagsFromLineText(line)
             );
             const isSame = currentLabels.length === desiredLabels.length
                 && currentLabels.every((label, idx) => label === desiredLabels[idx]);
@@ -648,7 +648,7 @@ export class FileOperation   {
     }
 
     async syncTaskNoteToFile(taskId: string, noteContent: string, noteDate: string): Promise<boolean> {
-        const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId);
+        const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId);
         if (!taskMapping) return false;
         const filepath = taskMapping.filePath;
 
@@ -659,7 +659,7 @@ export class FileOperation   {
 
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i];
-            if (line.includes(taskId) && this.plugin.taskParser.hasTodoistTag(line)) {
+            if (line.includes(taskId) && this.plugin.taskParser!.hasTodoistTag(line)) {
                 const indent = '\t'.repeat(line.length - line.trimStart().length + 1);
                 const noteLine = `${indent}- ${noteDate} ${noteContent}`;
                 // skip if note already exists in next lines
@@ -745,18 +745,8 @@ export class FileOperation   {
 
 
     isMarkdownFile(filename:string) {
-        // 获取文件名的扩展名
-        let extension = filename.split('.').pop();
-      
-        // 将扩展名转换为小写（Markdown文件的扩展名通常是.md）
-        extension = extension.toLowerCase();
-      
-        // 判断扩展名是否为.md
-        if (extension === 'md') {
-          return true;
-        } else {
-          return false;
-        }
+        const extension = filename.split('.').pop();
+        return extension?.toLowerCase() === 'md';
       }
 
     /**
@@ -905,11 +895,11 @@ export class FileOperation   {
                     }
                     
                     const match = line.match(/%%\[todoist_id::\s*([\w-]+)\]%%/);
-                        const taskContent = this.plugin.taskParser.getTaskContentFromLineText(line);
+                        const taskContent = this.plugin.taskParser!.getTaskContentFromLineText(line);
                         const isCompleted = /\[x\]/i.test(line);
                         const labels = this.extractLabelsFromLine(line);
-                        const dueDate = this.plugin.taskParser.getDueDateFromLineText(line) || undefined;
-                        const priority = this.plugin.taskParser.getTaskPriority(line);
+                        const dueDate = this.plugin.taskParser!.getDueDateFromLineText(line) || undefined;
+                        const priority = this.plugin.taskParser!.getTaskPriority(line);
                     
                     if (match && match[1]) {
                         const taskId = match[1];
@@ -986,7 +976,7 @@ export class FileOperation   {
      * @returns 标签数组（不带 # 前缀）
      */
     private extractLabelsFromLine(line: string): string[] {
-        return this.plugin.taskParser.getAllTagsFromLineText(line);
+        return this.plugin.taskParser!.getAllTagsFromLineText(line);
     }
 
 

--- a/src/vault/fileOperation.ts
+++ b/src/vault/fileOperation.ts
@@ -43,6 +43,15 @@ export class FileOperation   {
 
 	}
 
+    private requireFile(filepath: string): TFile {
+        const file = this.app.vault.getAbstractFileByPath(filepath);
+        if (!(file instanceof TFile)) {
+            throw new Error(`File not found: ${filepath}`);
+        }
+
+        return file;
+    }
+
 	/**
 	 * Check if a file path should be excluded from Full Vault Sync.
 	 * Excluded: dot-prefix dirs, plugin storage dir, Obsidian templates folder, *.excalidraw.md
@@ -127,7 +136,7 @@ export class FileOperation   {
         const filepath = taskMapping.filePath
     
         // 获取文件对象并更新内容
-        const file = this.app.vault.getAbstractFileByPath(filepath)
+        const file = this.requireFile(filepath)
         const content = await this.app.vault.read(file)
     
         const lines = content.split('\n')
@@ -161,7 +170,7 @@ export class FileOperation   {
         const filepath = taskMapping.filePath
     
         // 获取文件对象并更新内容
-        const file = this.app.vault.getAbstractFileByPath(filepath)
+        const file = this.requireFile(filepath)
         const content = await this.app.vault.read(file)
     
         const lines = content.split('\n')
@@ -195,11 +204,7 @@ export class FileOperation   {
             return;
         }
         const filepath = taskMapping.filePath;
-        const file = this.app.vault.getAbstractFileByPath(filepath);
-        if (!file) {
-            console.error(`[FileOperation] unbindTaskInFile: File not found: ${filepath}`);
-            return;
-        }
+        const file = this.requireFile(filepath);
         const content = await this.app.vault.read(file);
         const lines = content.split('\n');
         let modified = false;
@@ -227,18 +232,14 @@ export class FileOperation   {
         if (modified) {
             const newContent = lines.join('\n');
             await this.app.vault.modify(file, newContent);
-            this.plugin.logOperation?.log('FILE_TASK_UNBOUND', `Unbound task from file: ${taskId}`, filepath, taskId, 'manual');
+            this.plugin.logOperation?.log('FILE_TASK_UNBOUND', `Unbound task from file: ${taskId}`, filepath, taskId, 'obsidian→todoist');
         }
     }
     //add #todoist at the end of task line, if full vault sync enabled
     async addTodoistTagToFile(filepath: string) {    
         if (this.isFileExcludedFromSync(filepath)) return;
-        const file = this.app.vault.getAbstractFileByPath(filepath)
-        if (!file) {
-            this.plugin.debugLog(`[addTodoistTagToFile] File not found: ${filepath}`);
-            return;
-        }
-        const content = await this.app.vault.read(file as TFile)
+        const file = this.requireFile(filepath)
+        const content = await this.app.vault.read(file)
     
         const lines = content.split('\n')
         let modified = false
@@ -281,7 +282,7 @@ export class FileOperation   {
     //add todoist at the line
     async addTodoistLinkToFile(filepath: string) {    
         // 获取文件对象并更新内容
-        const file = this.app.vault.getAbstractFileByPath(filepath)
+        const file = this.requireFile(filepath)
         const content = await this.app.vault.read(file)
     
         const lines = content.split('\n')
@@ -328,7 +329,7 @@ export class FileOperation   {
 
 
     // sync updated task content  to file
-    async syncUpdatedTaskContentToTheFile(evt:Object) {
+    async syncUpdatedTaskContentToTheFile(evt:any) {
         const taskId = evt.object_id
         // 获取任务文件路径
         const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId)
@@ -339,7 +340,7 @@ export class FileOperation   {
         const filepath = taskMapping.filePath
     
         // 获取文件对象并更新内容
-        const file = this.app.vault.getAbstractFileByPath(filepath)
+        const file = this.requireFile(filepath)
         const content = await this.app.vault.read(file)
     
         const lines = content.split('\n')
@@ -368,7 +369,7 @@ export class FileOperation   {
     }
 
     // sync updated task due date  to the file
-    async syncUpdatedTaskDueDateToTheFile(evt:Object) {
+    async syncUpdatedTaskDueDateToTheFile(evt:any) {
         const taskId = evt.object_id
         // 获取任务文件路径
         const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId)
@@ -379,7 +380,7 @@ export class FileOperation   {
         const filepath = taskMapping.filePath
     
         // 获取文件对象并更新内容
-        const file = this.app.vault.getAbstractFileByPath(filepath)
+        const file = this.requireFile(filepath)
         const content = await this.app.vault.read(file)
     
         const lines = content.split('\n')
@@ -427,7 +428,7 @@ export class FileOperation   {
 
 
     // sync new task note to file
-    async syncAddedTaskNoteToTheFile(evt:Object) {
+    async syncAddedTaskNoteToTheFile(evt:any) {
 
 
         const taskId = evt.parent_item_id
@@ -442,7 +443,7 @@ export class FileOperation   {
         const filepath = taskMapping.filePath
     
         // 获取文件对象并更新内容
-        const file = this.app.vault.getAbstractFileByPath(filepath)
+        const file = this.requireFile(filepath)
         const content = await this.app.vault.read(file)
     
         const lines = content.split('\n')
@@ -475,7 +476,7 @@ export class FileOperation   {
         if (!taskMapping) return false;
         const filepath = taskMapping.filePath;
 
-        const file = this.app.vault.getAbstractFileByPath(filepath);
+        const file = this.requireFile(filepath);
         const fileContent = await this.app.vault.read(file);
         const lines = fileContent.split('\n');
         let modified = false;
@@ -506,7 +507,7 @@ export class FileOperation   {
         if (!taskMapping) return false;
         const filepath = taskMapping.filePath;
 
-        const file = this.app.vault.getAbstractFileByPath(filepath);
+        const file = this.requireFile(filepath);
         const fileContent = await this.app.vault.read(file);
         const lines = fileContent.split('\n');
         let modified = false;
@@ -556,7 +557,7 @@ export class FileOperation   {
         if (!taskMapping) return false;
         const filepath = taskMapping.filePath;
 
-        const file = this.app.vault.getAbstractFileByPath(filepath);
+        const file = this.requireFile(filepath);
         const fileContent = await this.app.vault.read(file);
         const lines = fileContent.split('\n');
         let modified = false;
@@ -601,7 +602,7 @@ export class FileOperation   {
         if (!taskMapping) return false;
         const filepath = taskMapping.filePath;
 
-        const file = this.app.vault.getAbstractFileByPath(filepath);
+        const file = this.requireFile(filepath);
         const fileContent = await this.app.vault.read(file);
         const lines = fileContent.split('\n');
         let modified = false;
@@ -651,7 +652,7 @@ export class FileOperation   {
         if (!taskMapping) return false;
         const filepath = taskMapping.filePath;
 
-        const file = this.app.vault.getAbstractFileByPath(filepath);
+        const file = this.requireFile(filepath);
         const fileContent = await this.app.vault.read(file);
         const lines = fileContent.split('\n');
         let modified = false;
@@ -681,7 +682,7 @@ export class FileOperation   {
     //避免使用该方式，通过view可以获得实时更新的value
     async readContentFromFilePath(filepath:string){
         try {
-            const file = this.app.vault.getAbstractFileByPath(filepath);
+            const file = this.requireFile(filepath);
             const content = await this.app.vault.read(file);
             return content
         } catch (error) {
@@ -693,7 +694,7 @@ export class FileOperation   {
 
     //search todoist_id by content
     async searchTodoistIdFromFilePath(filepath: string, searchTerm: string): Promise<string | null> {
-        const file = this.app.vault.getAbstractFileByPath(filepath)
+        const file = this.requireFile(filepath)
         const fileContent = await this.app.vault.read(file)
         const fileLines = fileContent.split('\n');
         let todoistId: string | null = null;
@@ -768,13 +769,7 @@ export class FileOperation   {
     ): Promise<boolean> {
         try {
             console.log(`[updateTaskIdInVault] start file=${filePath} oldId=${oldId} newId=${newId}`);
-            const file = this.app.vault.getAbstractFileByPath(filePath);
-            if (!file) {
-                console.error(`[updateTaskIdInVault] File not found: ${filePath}`);
-                this.plugin.debugLog(filePath)
-                console.log(`[updateTaskIdInVault] fail file-not-found file=${filePath}`);
-                return false;
-            }
+            const file = this.requireFile(filePath);
             
             const content = await this.app.vault.read(file);
             const lines = content.split('\n');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "isolatedModules": true,
-  "strictNullChecks": false,
+    "strictNullChecks": true,
     "lib": [
       "DOM",
       "ES5",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "isolatedModules": true,
-	"strictNullChecks": true,
+  "strictNullChecks": false,
     "lib": [
       "DOM",
       "ES5",


### PR DESCRIPTION
As described in
https://www.npmjs.com/package/@doist/todoist-api-typescript, ultimate todoist sync should switch from using `@doist/todoist-api-typescript` to using `@doist/todoist-sdk`

fixes #111 