### PR TITLE
fix: repair Obsidian to Todoist sync on top of the new SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,9 @@ opencode-session-history
 
 data.json
 /.sisyphus/
-/tests/
+/tests/*
+!/tests/unit/
+tests/.build/
 AGENTS.md
 device-id
 /.stfolder/

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # npm
 node_modules
+.pixi
 
 # Don't include the compiled main.js file in the repo.
 # They should be uploaded to GitHub releases instead.
@@ -36,3 +37,6 @@ data.json
 AGENTS.md
 device-id
 /.stfolder/
+# pixi environments
+.pixi/*
+!.pixi/config.toml

--- a/README.md
+++ b/README.md
@@ -80,7 +80,19 @@ If you would rather install the plugin manually, you can do the following:
 
    Each direction can be independently enabled or disabled.
 
-4. **Reverse sync scope** (Todoist → Obsidian)
+4. **Forward sync scope** (Obsidian → Todoist)
+   - *Everything* (default): the vault line is kept as the source of truth — edits
+     to text, due date, priority and labels are pushed, and removing the line
+     deletes the task in Todoist.
+   - *Create and complete only*: new tasks and completion are sent, and nothing
+     else. Removing a line unlinks the task rather than deleting it.
+
+   Pick the second if you capture tasks in Obsidian and then work on them in
+   Todoist. Under *Everything*, a vault line that has drifted from the task — a
+   reworded title, a date changed in Todoist — is pushed back over the Todoist
+   version on the next sync.
+
+5. **Reverse sync scope** (Todoist → Obsidian)
    - *Completion and due date* (default): a task ticked off or re-dated in Todoist
      is updated in your vault. Nothing else on the line is touched.
    - *Everything*: also applies content, priority and labels, and appends Todoist
@@ -91,10 +103,10 @@ If you would rather install the plugin manually, you can do the following:
    Todoist is overwritten on the next push, since the vault's value reads as the
    newer edit. This is why completion and due date are always pulled.
 
-5. **Full vault sync**
+6. **Full vault sync**
    By enabling this option, the plugin will automatically add `#todoist` to all tasks in your vault.
 
-6. **Excluded folders**
+7. **Excluded folders**
    Select folders to exclude from Full Vault Sync. Template folders, hidden folders, and plugin storage are excluded automatically.
 
 

--- a/README.md
+++ b/README.md
@@ -81,11 +81,15 @@ If you would rather install the plugin manually, you can do the following:
    Each direction can be independently enabled or disabled.
 
 4. **Reverse sync scope** (Todoist → Obsidian)
-   - *Completion only* (default): a task ticked off in Todoist gets ticked off in
-     your vault. Nothing else on the line is touched.
-   - *Everything*: also applies content, due date, priority and labels, and appends
-     Todoist comments as sub-items. These rewrite the task line — tag order and
-     spacing are normalised — and can overwrite text you edited in Obsidian.
+   - *Completion and due date* (default): a task ticked off or re-dated in Todoist
+     is updated in your vault. Nothing else on the line is touched.
+   - *Everything*: also applies content, priority and labels, and appends Todoist
+     comments as sub-items. These rewrite the task line — tag order and spacing are
+     normalised — and can overwrite text you edited in Obsidian.
+
+   Fields outside the chosen scope are owned by Obsidian: changing one of them in
+   Todoist is overwritten on the next push, since the vault's value reads as the
+   newer edit. This is why completion and due date are always pulled.
 
 5. **Full vault sync**
    By enabling this option, the plugin will automatically add `#todoist` to all tasks in your vault.

--- a/README.md
+++ b/README.md
@@ -80,10 +80,17 @@ If you would rather install the plugin manually, you can do the following:
 
    Each direction can be independently enabled or disabled.
 
-4. **Full vault sync**
+4. **Reverse sync scope** (Todoist → Obsidian)
+   - *Completion only* (default): a task ticked off in Todoist gets ticked off in
+     your vault. Nothing else on the line is touched.
+   - *Everything*: also applies content, due date, priority and labels, and appends
+     Todoist comments as sub-items. These rewrite the task line — tag order and
+     spacing are normalised — and can overwrite text you edited in Obsidian.
+
+5. **Full vault sync**
    By enabling this option, the plugin will automatically add `#todoist` to all tasks in your vault.
 
-5. **Excluded folders**
+6. **Excluded folders**
    Select folders to exclude from Full Vault Sync. Template folders, hidden folders, and plugin storage are excluded automatically.
 
 
@@ -114,7 +121,7 @@ You can see the current file's default project in the status bar at the bottom r
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) (v16+)
+- [Node.js](https://nodejs.org/) (v18+ — `npm test` uses the built-in test runner)
 - npm
 - An Obsidian vault for testing
 
@@ -141,6 +148,34 @@ npm run build
 
 After each rebuild, reload Obsidian (`Ctrl/Cmd+P` → "Reload app without saving") or disable and re-enable the plugin in settings.
 
+### Tests
+
+```bash
+# Run the unit tests
+npm test
+
+# Run a single test file
+node --test tests/unit/editorContentDiff.test.mjs
+```
+
+`npm test` runs Node's built-in test runner over `tests/unit/`. A `pretest` step
+bundles the modules under test to `tests/.build/` first (they are TypeScript, and
+the tests import the compiled output), so run `npm test` rather than `node --test`
+on its own after changing source — or the tests will run against a stale bundle.
+
+Tests cover the pure decision logic that is expensive to get wrong and awkward to
+verify by hand in Obsidian:
+
+| Module | What is covered |
+| --- | --- |
+| `src/vault/editorContentDiff.ts` | The line-range edit used to write into an open editor. A wrong range corrupts the user's note, so this is checked against a fake editor that rejects out-of-range positions, over hand-written cases plus 20k randomised document pairs. |
+| `src/sync/vanishedTaskAction.ts` | What to do about a task missing from the Sync API response — completed in Todoist, deleted, or not yet synced. Getting it wrong either disables a live task or keeps pushing to a deleted one. |
+
+Logic that needs the Obsidian or Todoist API is not unit-tested; verify those by
+running the plugin against a real vault (see Manual Install below). When adding a
+test, prefer extracting the decision into a module with no `obsidian` import — that
+is what makes it importable from a test at all.
+
 ### Project Structure
 
 ```
@@ -154,6 +189,7 @@ src/
 ├── settings/        # Settings UI and migration
 ├── plugin/          # Event handlers and lifecycle
 └── ui/              # Modals (task manager, project picker)
+tests/unit/          # Unit tests (see Tests above)
 ```
 
 ### Manual Install

--- a/main.ts
+++ b/main.ts
@@ -245,7 +245,12 @@ export default class UltimateTodoistSyncForObsidian extends Plugin {
 				this.debugLog('Startup database check passed');
 				return true;
 			} else {
-				new Notice(`Found ${result.totalIssues} database issue(s). Please use "Fix Database" in settings to resolve them.`);
+				// Settled tasks are excluded: a completed task that has left Todoist's
+				// active set is a normal end state, and reporting it on every launch
+				// trained the warning to be ignored.
+				const settled = result.summary.taskNonActive;
+				const settledNote = settled > 0 ? ` (${settled} settled task(s) need no action.)` : '';
+				new Notice(`Found ${result.actionableIssues} database issue(s). Please use "Fix Database" in settings to resolve them.${settledNote}`);
 				return true;
 			}
 		} catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "ultimate-todoist-sync",
-	"version": "1.0.0",
+	"version": "2.0.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ultimate-todoist-sync",
-			"version": "1.0.0",
+			"version": "2.0.3",
 			"license": "GNU GPLv3",
 			"dependencies": {
-				"@doist/todoist-api-typescript": "^6.5.0"
+				"@doist/todoist-sdk": "^10.1.0"
 			},
 			"devDependencies": {
 				"@types/node": "^16.11.6",
@@ -19,7 +19,7 @@
 				"esbuild": "0.17.3",
 				"obsidian": "latest",
 				"tslib": "2.4.0",
-				"typescript": "4.7.4"
+				"typescript": "5.6.3"
 			}
 		},
 		"node_modules/@codemirror/state": {
@@ -41,25 +41,50 @@
 				"w3c-keyname": "^2.2.4"
 			}
 		},
-		"node_modules/@doist/todoist-api-typescript": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@doist/todoist-api-typescript/-/todoist-api-typescript-6.5.0.tgz",
-			"integrity": "sha512-Hvtqb0EsBTN4gz4xsQ+VbYasZeEhNxuNa+CrCcGB+YWoRJipMmm4dXmzceYXKT8gx8UgVdyV7CDIEXrFQC/hFw==",
+		"node_modules/@doist/todoist-sdk": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-10.1.0.tgz",
+			"integrity": "sha512-o4AM0YGcQLlNyHOZ126qCfa+FQHsgNOKWpfZCECtjm6a+7tsiU39E/em3Ihcaynh7nUkYRXEVC8RUQ0kkCkJXw==",
 			"license": "MIT",
 			"dependencies": {
 				"camelcase": "6.3.0",
 				"emoji-regex": "10.6.0",
-				"form-data": "4.0.4",
+				"form-data": "4.0.5",
 				"ts-custom-error": "^3.2.0",
 				"undici": "^7.16.0",
 				"uuid": "11.1.0",
-				"zod": "4.1.12"
+				"zod": "4.3.6"
 			},
 			"engines": {
-				"node": ">=20.0.0"
+				"node": ">=20.18.1"
 			},
 			"peerDependencies": {
-				"type-fest": "^4.12.0"
+				"type-fest": "^4.12.0 || ^5.5.0"
+			}
+		},
+		"node_modules/@doist/todoist-sdk/node_modules/form-data": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+			"license": "MIT",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/@doist/todoist-sdk/node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
@@ -419,6 +444,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
 			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"eslint-visitor-keys": "^3.3.0"
 			},
@@ -434,6 +460,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.1.tgz",
 			"integrity": "sha512-BISJ6ZE4xQsuL/FmsyRaiffpq977bMlsKfGHTQrOGFErfByxIe6iZTxPf/00Zon9b9a7iUykfQwejN3s2ZW/Bw==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
@@ -443,6 +470,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.1.tgz",
 			"integrity": "sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
@@ -466,6 +494,7 @@
 			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
 			"integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
@@ -475,6 +504,7 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
 			"integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@humanwhocodes/object-schema": "^1.2.1",
 				"debug": "^4.1.1",
@@ -489,6 +519,7 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
 			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=12.22"
 			},
@@ -501,7 +532,8 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -612,7 +644,6 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.29.0.tgz",
 			"integrity": "sha512-ruKWTv+x0OOxbzIw9nW5oWlUopvP/IQDjB5ZqmTglLIoDTctLlAJpAQFpNPJP/ZI7hTT9sARBosEfaKbcFuECw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "5.29.0",
 				"@typescript-eslint/types": "5.29.0",
@@ -777,6 +808,7 @@
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
 			"dev": true,
+			"peer": true,
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
@@ -786,6 +818,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -802,6 +835,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -811,6 +845,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -825,7 +860,8 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
@@ -846,13 +882,15 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -900,6 +938,7 @@
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -921,6 +960,7 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -937,6 +977,7 @@
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -948,7 +989,8 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
@@ -966,13 +1008,15 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
 			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -1003,7 +1047,8 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/delayed-stream": {
 			"version": "1.0.0",
@@ -1031,6 +1076,7 @@
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
 			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"esutils": "^2.0.2"
 			},
@@ -1145,6 +1191,7 @@
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -1264,6 +1311,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
 			"integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
@@ -1277,6 +1325,7 @@
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -1286,6 +1335,7 @@
 			"resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
 			"integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"acorn": "^8.8.0",
 				"acorn-jsx": "^5.3.2",
@@ -1303,6 +1353,7 @@
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
 			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"estraverse": "^5.1.0"
 			},
@@ -1315,6 +1366,7 @@
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -1354,6 +1406,7 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1362,7 +1415,8 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/fast-glob": {
 			"version": "3.2.12",
@@ -1396,13 +1450,15 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/fastq": {
 			"version": "1.15.0",
@@ -1418,6 +1474,7 @@
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
 			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"flat-cache": "^3.0.4"
 			},
@@ -1442,6 +1499,7 @@
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
 			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -1458,6 +1516,7 @@
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
 			"integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"flatted": "^3.1.0",
 				"rimraf": "^3.0.2"
@@ -1470,29 +1529,15 @@
 			"version": "3.2.7",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-			"dev": true
-		},
-		"node_modules/form-data": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-			"license": "MIT",
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
@@ -1551,6 +1596,7 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
 			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -1571,6 +1617,7 @@
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
 			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"is-glob": "^4.0.3"
 			},
@@ -1583,6 +1630,7 @@
 			"resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
 			"integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
 			},
@@ -1599,6 +1647,7 @@
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true,
 			"license": "(MIT OR CC0-1.0)",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -1642,13 +1691,15 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
 			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -1706,6 +1757,7 @@
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
 			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
@@ -1722,6 +1774,7 @@
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.8.19"
 			}
@@ -1731,6 +1784,7 @@
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -1740,7 +1794,8 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
@@ -1777,6 +1832,7 @@
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -1785,13 +1841,15 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/js-sdsl": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
 			"integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
 			"dev": true,
+			"peer": true,
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/js-sdsl"
@@ -1802,6 +1860,7 @@
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -1813,19 +1872,22 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/levn": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
 			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
@@ -1839,6 +1901,7 @@
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
 			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"p-locate": "^5.0.0"
 			},
@@ -1853,7 +1916,8 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
@@ -1924,6 +1988,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -1950,7 +2015,8 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/obsidian": {
 			"version": "1.1.1",
@@ -1971,6 +2037,7 @@
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"wrappy": "1"
 			}
@@ -1980,6 +2047,7 @@
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
 			"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
@@ -1997,6 +2065,7 @@
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
 			},
@@ -2012,6 +2081,7 @@
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
 			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"p-limit": "^3.0.2"
 			},
@@ -2027,6 +2097,7 @@
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"callsites": "^3.0.0"
 			},
@@ -2039,6 +2110,7 @@
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2048,6 +2120,7 @@
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2057,6 +2130,7 @@
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2087,6 +2161,7 @@
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.8.0"
 			}
@@ -2096,6 +2171,7 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
 			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -2137,6 +2213,7 @@
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -2156,6 +2233,7 @@
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -2209,6 +2287,7 @@
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
 			},
@@ -2221,6 +2300,7 @@
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2239,6 +2319,7 @@
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -2251,6 +2332,7 @@
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -2262,13 +2344,15 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.2.tgz",
 			"integrity": "sha512-C4myMmRTO8iaC5Gg+N1ftK2WT4eXUTMAa+HEFPPrfVeO/NtqLTtAmV1HbqnuGtLwCek44Ra76fdGUkSqjiMPcQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -2280,7 +2364,8 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -2334,6 +2419,7 @@
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
 			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1"
 			},
@@ -2355,17 +2441,17 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.7.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+			"version": "5.6.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+			"integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
 			"dev": true,
-			"peer": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/undici": {
@@ -2382,6 +2468,7 @@
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
@@ -2403,13 +2490,15 @@
 			"version": "2.2.6",
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.6.tgz",
 			"integrity": "sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"isexe": "^2.0.0"
 			},
@@ -2425,6 +2514,7 @@
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
 			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2433,7 +2523,8 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/yallist": {
 			"version": "4.0.0",
@@ -2446,20 +2537,12 @@
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/zod": {
-			"version": "4.1.12",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
-			"integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"esbuild": "0.17.3",
 		"obsidian": "latest",
 		"tslib": "2.4.0",
-		"typescript": "4.7.4"
+		"typescript": "5.6.3"
 	},
 	"dependencies": {
 		"@doist/todoist-api-typescript": "^6.5.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"build-without-tsc": "node esbuild.config.mjs production",
-		"pretest": "esbuild src/vault/editorContentDiff.ts src/sync/vanishedTaskAction.ts --bundle --format=esm --outbase=src --outdir=tests/.build --out-extension:.js=.mjs",
+		"pretest": "esbuild src/vault/editorContentDiff.ts src/sync/vanishedTaskAction.ts src/data/taskContent.ts --bundle --format=esm --outbase=src --outdir=tests/.build --out-extension:.js=.mjs",
 		"test": "node --test tests/unit/",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
 		"typescript": "5.6.3"
 	},
 	"dependencies": {
-		"@doist/todoist-api-typescript": "^6.5.0"
+		"@doist/todoist-sdk": "^10.1.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"build-without-tsc": "node esbuild.config.mjs production",
+		"pretest": "esbuild src/vault/editorContentDiff.ts --bundle --format=esm --outfile=tests/.build/editorContentDiff.mjs",
+		"test": "node --test tests/unit/",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},
 	"keywords": [],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"build-without-tsc": "node esbuild.config.mjs production",
-		"pretest": "esbuild src/vault/editorContentDiff.ts --bundle --format=esm --outfile=tests/.build/editorContentDiff.mjs",
+		"pretest": "esbuild src/vault/editorContentDiff.ts src/sync/vanishedTaskAction.ts --bundle --format=esm --outbase=src --outdir=tests/.build --out-extension:.js=.mjs",
 		"test": "node --test tests/unit/",
 		"version": "node version-bump.mjs && git add manifest.json versions.json"
 	},

--- a/src/api/restApi.ts
+++ b/src/api/restApi.ts
@@ -285,17 +285,37 @@ export class TodoistRestAPI  {
     async getTaskCompletionState(taskId: string): Promise<'completed' | 'active' | 'missing' | 'unknown'> {
         if (!taskId) return 'unknown';
 
-        try {
-            const task = await this.initializeAPI().getTask(taskId);
-            if (!task) return 'missing';
-            if ((task as { isDeleted?: boolean }).isDeleted) return 'missing';
-            return task.checked ? 'completed' : 'active';
-        } catch (error) {
-            const statusCode = (error as { httpStatusCode?: number })?.httpStatusCode;
-            if (statusCode === 404) return 'missing';
-            console.warn(`[TodoistRestAPI] Could not determine completion state for ${taskId}:`, error);
-            return 'unknown';
+        // These calls go through the SDK, which does not pass through the plugin's
+        // own rate-limit accounting, so a repair sweep over many tasks can walk
+        // into a 429. Without this retry a throttled batch would silently report
+        // 'unknown' and look identical to "nothing happened".
+        const MAX_ATTEMPTS = 3;
+        for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            try {
+                const task = await this.initializeAPI().getTask(taskId);
+                if (!task) return 'missing';
+                if ((task as { isDeleted?: boolean }).isDeleted) return 'missing';
+                return task.checked ? 'completed' : 'active';
+            } catch (error) {
+                const statusCode = (error as { httpStatusCode?: number })?.httpStatusCode;
+                if (statusCode === 404) return 'missing';
+
+                if (statusCode === 429 && attempt < MAX_ATTEMPTS) {
+                    const retryAfterSeconds = Number((error as { responseData?: { error_extra?: { retry_after?: unknown } } })?.responseData?.error_extra?.retry_after);
+                    const waitMs = Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
+                        ? Math.min(retryAfterSeconds * 1000, 30_000)
+                        : attempt * 1000;
+                    this.plugin.debugLog(`[TodoistRestAPI] Rate limited on ${taskId}, retrying in ${waitMs}ms (attempt ${attempt}/${MAX_ATTEMPTS})`);
+                    await new Promise(resolve => setTimeout(resolve, waitMs));
+                    continue;
+                }
+
+                console.warn(`[TodoistRestAPI] Could not determine completion state for ${taskId} (HTTP ${statusCode ?? 'n/a'}):`, error);
+                return 'unknown';
+            }
         }
+
+        return 'unknown';
     }
 
     // get a task by Id

--- a/src/api/restApi.ts
+++ b/src/api/restApi.ts
@@ -1,29 +1,74 @@
-import { TodoistApi } from "@doist/todoist-api-typescript"
-import { App} from 'obsidian';
+import { TodoistApi } from "@doist/todoist-sdk"
+import { App, requestUrl, type RequestUrlParam, type RequestUrlResponse } from 'obsidian';
 import UltimateTodoistSyncForObsidian from "../../main";
-    //convert date from obsidian event
-    // 使用示例
-    //const str = "2023-03-27";
-    //const utcStr = localDateStringToUTCDatetimeString(str);
-    //this.plugin.debugLog(dateStr); // 输出 2023-03-27T00:00:00.000Z
-function  localDateStringToUTCDatetimeString(localDateString:string) {
-        try {
-          if(localDateString === null){
-            return null
-          }
-          localDateString = localDateString + "T08:00";
-          let localDateObj = new Date(localDateString);
-          let ISOString = localDateObj.toISOString()
-          return(ISOString);
-        } catch (error) {
-          console.error(`Error extracting date from string '${localDateString}': ${error}`);
-          return null;
-        }
+type IdMappingObjectName = 'projects' | 'tasks' | 'sections';
+
+function normalizeRequestHeaders(headers?: HeadersInit): Record<string, string> {
+  if (!headers) {
+    return {};
+  }
+
+  if (headers instanceof Headers) {
+    const normalizedHeaders: Record<string, string> = {};
+    headers.forEach((value, key) => {
+      normalizedHeaders[key] = String(value);
+    });
+    return normalizedHeaders;
+  }
+
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers.map(([key, value]) => [key, String(value)]));
+  }
+
+  return Object.fromEntries(Object.entries(headers).map(([key, value]) => [key, String(value)]));
+}
+
+function normalizeResponseHeaders(headers: RequestUrlResponse['headers']): Record<string, string> {
+  if (!headers || typeof headers !== 'object') {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key, Array.isArray(value) ? value.join(', ') : String(value)])
+  );
+}
+
+function createObsidianFetchAdapter(requestUrlFn: (request: RequestUrlParam | string) => Promise<RequestUrlResponse>) {
+  return async (url: string, options?: RequestInit & { timeout?: number }) => {
+    const body = options?.body;
+    const normalizedBody = typeof body === 'string'
+      ? body
+      : body instanceof URLSearchParams
+        ? body.toString()
+        : body == null
+          ? undefined
+          : String(body);
+
+    const response = await requestUrlFn({
+      url,
+      method: options?.method ?? 'GET',
+      headers: normalizeRequestHeaders(options?.headers),
+      body: normalizedBody,
+      throw: false,
+    });
+
+    return {
+      ok: response.status >= 200 && response.status < 300,
+      status: response.status,
+      statusText: '',
+      headers: normalizeResponseHeaders(response.headers),
+      text: async () => typeof response.text === 'string' ? response.text : JSON.stringify(response.json ?? ''),
+      json: async () => response.json,
+    };
+  };
 }
 
 export class TodoistRestAPI  {
 	app:App;
   plugin: UltimateTodoistSyncForObsidian;
+  private api: TodoistApi | null = null;
+  private apiToken = '';
+  private readonly idMappingCache = new Map<string, string>();
 
 	constructor(app:App, plugin:UltimateTodoistSyncForObsidian) {
 		//super(app,settings);
@@ -31,29 +76,104 @@ export class TodoistRestAPI  {
     this.plugin = plugin;
 	}
 
-
-    initializeAPI(){
-        const token = this.plugin.settings.todoistAPIToken
-        const api = new TodoistApi(token)
-        return(api)
+  private getApi(): TodoistApi {
+    const token = this.plugin.settings.todoistAPIToken;
+    if (!token) {
+      throw new Error('Todoist API token is missing');
     }
 
-    async AddTask({ projectId, content, parentId = null, dueDate, dueDatetime,labels, description,priority }: { projectId: string, content: string, parentId?: string , dueDate?: string,dueDatetime?: string, labels?: Array<string>, description?: string,priority?:number }) {
-        const api = await this.initializeAPI()
+    if (!this.api || this.apiToken !== token) {
+      this.api = new TodoistApi(token, {
+        customFetch: createObsidianFetchAdapter(requestUrl),
+      });
+      this.apiToken = token;
+      this.idMappingCache.clear();
+    }
+
+    return this.api;
+  }
+
+  private isLegacyNumericId(id?: string | null): id is string {
+    return typeof id === 'string' && /^\d+$/.test(id);
+  }
+
+  async resolveId(objName: IdMappingObjectName, id?: string | null): Promise<string | undefined> {
+    if (!id) {
+      return undefined;
+    }
+
+    if (!this.isLegacyNumericId(id)) {
+      return id;
+    }
+
+    const cacheKey = `${objName}:${id}`;
+    const cached = this.idMappingCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const mappings = await this.getApi().getIdMappings({
+      objName,
+      objIds: [id],
+    });
+
+    const resolved = mappings.find((entry) => entry.oldId === id)?.newId ?? id;
+    if (resolved && resolved !== id) {
+      this.idMappingCache.set(cacheKey, resolved);
+    }
+
+    return resolved;
+  }
+
+  async resolveIds(objName: IdMappingObjectName, ids: string[]): Promise<Record<string, string>> {
+    const uniqueIds = Array.from(new Set(ids.filter((id): id is string => this.isLegacyNumericId(id))));
+    if (uniqueIds.length === 0) {
+      return {};
+    }
+
+    const uncached = uniqueIds.filter((id) => !this.idMappingCache.has(`${objName}:${id}`));
+    if (uncached.length > 0) {
+      const mappings = await this.getApi().getIdMappings({
+        objName,
+        objIds: uncached as [string, ...string[]],
+      });
+
+      for (const mapping of mappings) {
+        if (mapping.oldId && mapping.newId) {
+          this.idMappingCache.set(`${objName}:${mapping.oldId}`, mapping.newId);
+        }
+      }
+    }
+
+    return Object.fromEntries(uniqueIds.map((id) => [id, this.idMappingCache.get(`${objName}:${id}`) ?? id]));
+  }
+
+    initializeAPI(){
+        return this.getApi()
+    }
+
+    async AddTask({ projectId, content, parentId, dueDate, dueDatetime,labels, description,priority }: { projectId?: string, content: string, parentId?: string | null , dueDate?: string,dueDatetime?: string, labels?: Array<string>, description?: string,priority?:number }) {
+        const api = this.initializeAPI()
         try {
-          if(dueDate){
-            dueDatetime = localDateStringToUTCDatetimeString(dueDate)
-            dueDate = undefined
-          }  
-          const newTask = await api.addTask({
-            projectId,
-            content,
-            parentId,
-            dueDate,
-            labels,
-            description,
-            priority
-          });
+      const addTaskArgs: Record<string, unknown> = {
+        content,
+        parentId: parentId || undefined,
+        labels,
+        description,
+        priority,
+      };
+
+      if (projectId) {
+        addTaskArgs.projectId = projectId;
+      }
+
+      if (dueDate) {
+        addTaskArgs.dueDate = dueDate;
+      } else if (dueDatetime) {
+        addTaskArgs.dueDatetime = dueDatetime;
+      }
+
+      const newTask = await api.addTask(addTaskArgs as any);
           return newTask;
         } catch (error) {
           throw new Error(`Error adding task: ${error.message}`);
@@ -63,11 +183,15 @@ export class TodoistRestAPI  {
 
     //options:{ projectId?: string, section_id?: string, label?: string , filter?: string,lang?: string, ids?: Array<string>}
     async GetActiveTasks(options:{ projectId?: string, section_id?: string, label?: string , filter?: string,lang?: string, ids?: Array<string>}) {
-      const api = await this.initializeAPI()
+      const api = this.initializeAPI()
       try {
-        const result = await api.getTasks(options);
-        // API v1 返回分页格式 { results: [], nextCursor: null }
-        return result.results || result;
+        const result = await api.getTasks({
+			projectId: options.projectId,
+			sectionId: options.section_id,
+			label: options.label,
+			ids: options.ids,
+		});
+        return result.results;
       } catch (error) {
         throw new Error(`Error get active tasks: ${error.message}`);
       }
@@ -77,7 +201,7 @@ export class TodoistRestAPI  {
     //Also note that to remove the due date of a task completely, you should set the due_string parameter to no date or no due date.
     //api 没有 update task project id 的函数
     async UpdateTask(taskId: string, updates: { content?: string, description?: string, labels?:Array<string>,dueDate?: string,dueDatetime?: string,dueString?:string,parentId?:string,priority?:number }) {
-        const api = await this.initializeAPI()
+        const api = this.initializeAPI()
         if (!taskId) {
         throw new Error('taskId is required');
         }
@@ -85,13 +209,26 @@ export class TodoistRestAPI  {
         throw new Error('At least one update is required');
         }
         try {
-        if(updates.dueDate){
-            this.plugin.debugLog(updates.dueDate)
-            updates.dueDatetime = localDateStringToUTCDatetimeString(updates.dueDate)
-            updates.dueDate = null
-            this.plugin.debugLog(updates.dueDatetime)
-          }  
-        const updatedTask = await api.updateTask(taskId, updates);
+        if (updates.parentId) {
+			await api.moveTask(taskId, { parentId: updates.parentId });
+		}
+
+    const updateTaskArgs: Record<string, unknown> = {
+      content: updates.content,
+      description: updates.description,
+      labels: updates.labels,
+      priority: updates.priority,
+    };
+
+    if (updates.dueDate) {
+      updateTaskArgs.dueDate = updates.dueDate;
+    } else if (updates.dueDatetime) {
+      updateTaskArgs.dueDatetime = updates.dueDatetime;
+    } else if (updates.dueString !== undefined) {
+      updateTaskArgs.dueString = updates.dueString || null;
+    }
+
+    const updatedTask = await api.updateTask(taskId, updateTaskArgs as any);
         return updatedTask;
         } catch (error) {
         throw new Error(`Error updating task: ${error.message}`);
@@ -102,23 +239,22 @@ export class TodoistRestAPI  {
 
 
     //open a task
-    async OpenTask(taskId:string) {
-        const api = await this.initializeAPI()
+    async OpenTask(taskId:string): Promise<boolean> {
+      const api = this.initializeAPI()
         try {
-    
         const isSuccess = await api.reopenTask(taskId);
         this.plugin.debugLog(`Task ${taskId} is reopend`)
         return(isSuccess)
     
         } catch (error) {
             console.error('Error open a  task:', error);
-            return
+            throw error;
         }
     }
 
     // Close a task in Todoist API
     async CloseTask(taskId: string): Promise<boolean> {
-        const api = await this.initializeAPI()
+      const api = this.initializeAPI()
         try {
         const isSuccess = await api.closeTask(taskId);
         this.plugin.debugLog(`Task ${taskId} is closed`)
@@ -134,7 +270,7 @@ export class TodoistRestAPI  {
  
     // get a task by Id
     async getTaskById(taskId: string) {
-        const api = await this.initializeAPI()
+      const api = this.initializeAPI()
         if (!taskId) {
         throw new Error('taskId is required');
         }
@@ -153,7 +289,7 @@ export class TodoistRestAPI  {
 
     //get a task due by id
     async getTaskDueById(taskId: string) {
-        const api = await this.initializeAPI()
+      const api = this.initializeAPI()
         if (!taskId) {
         throw new Error('taskId is required');
         }
@@ -169,17 +305,32 @@ export class TodoistRestAPI  {
 
     //get all projects
     async GetAllProjects() {
-        const api = await this.initializeAPI()
+        const api = this.initializeAPI()
         try {
-        const result = await api.getProjects();
-        // API v1 返回分页格式 { results: [], nextCursor: null }
-        return result.results || result;
+        const projects = [];
+    let cursor: string | null = null;
+    do {
+      const result = await api.getProjects({ cursor: cursor ?? undefined, limit: 200 });
+      projects.push(...result.results);
+      cursor = result.nextCursor;
+    } while (cursor);
+
+    return projects;
     
         } catch (error) {
             console.error('Error get all projects', error);
             return false
         }
     }
+
+  async DeleteTask(taskId: string): Promise<boolean> {
+    const api = this.initializeAPI();
+    try {
+      return await api.deleteTask(taskId);
+    } catch (error) {
+      throw new Error(`Error deleting task: ${error.message}`);
+    }
+  }
 
 
 }

--- a/src/api/restApi.ts
+++ b/src/api/restApi.ts
@@ -268,6 +268,36 @@ export class TodoistRestAPI  {
     
 
  
+    /**
+     * Ask Todoist directly what became of a task, for tasks that are absent from
+     * the sync response.
+     *
+     * `/api/v1/sync` only returns active items, so a task completed in Todoist
+     * disappears from it entirely instead of coming back with checked=true — which
+     * is indistinguishable from deletion without asking. This lookup is definitive
+     * regardless of how long ago the task was completed, unlike a completed-tasks
+     * query over a date window.
+     *
+     * Never throws: transport, auth and rate-limit failures all report 'unknown',
+     * because the callers use this to decide whether to disable a task's sync and
+     * must not do that on the strength of a failed request.
+     */
+    async getTaskCompletionState(taskId: string): Promise<'completed' | 'active' | 'missing' | 'unknown'> {
+        if (!taskId) return 'unknown';
+
+        try {
+            const task = await this.initializeAPI().getTask(taskId);
+            if (!task) return 'missing';
+            if ((task as { isDeleted?: boolean }).isDeleted) return 'missing';
+            return task.checked ? 'completed' : 'active';
+        } catch (error) {
+            const statusCode = (error as { httpStatusCode?: number })?.httpStatusCode;
+            if (statusCode === 404) return 'missing';
+            console.warn(`[TodoistRestAPI] Could not determine completion state for ${taskId}:`, error);
+            return 'unknown';
+        }
+    }
+
     // get a task by Id
     async getTaskById(taskId: string) {
       const api = this.initializeAPI()

--- a/src/api/syncApi.ts
+++ b/src/api/syncApi.ts
@@ -44,6 +44,8 @@ export class TodoistSyncAPI   {
 	// Store complete raw API response
 	// Store complete raw API response
 	private syncData: Record<string, any> | null = null;
+	// taskId → what a direct lookup said about a task missing from syncData.
+	private completionStateCache = new Map<string, 'completed' | 'missing'>();
 	// API-level sync lock — prevents concurrent incrementalSync/initializeSync
 	private _syncRunning = false;
 	private _syncDirty = false;
@@ -1066,6 +1068,33 @@ export class TodoistSyncAPI   {
       console.error('Error getting task by id:', error);
       throw error;
     }
+  }
+
+  /**
+   * What became of a task that is not in the sync data: 'completed', 'active',
+   * 'missing', or 'unknown' when Todoist could not be reached.
+   *
+   * Results are cached for the session so a task that stays gone — which is the
+   * normal state for a completed one — costs one request rather than one per
+   * sync pass. 'unknown' is never cached, so a failed lookup is retried.
+   */
+  async GetTaskCompletionState(taskId: string): Promise<'completed' | 'active' | 'missing' | 'unknown'> {
+    const cached = this.completionStateCache.get(taskId);
+    if (cached) return cached;
+
+    const restApi = this.plugin.todoistRestAPI;
+    if (!restApi) return 'unknown';
+
+    const resolvedId = (await this.resolveLegacyId('tasks', taskId)) || taskId;
+    const state = await restApi.getTaskCompletionState(resolvedId);
+    // Only terminal verdicts are cached. 'active' means the absence was transient,
+    // so caching it would hide a completion that happens later in the session, and
+    // 'unknown' means the question was never answered.
+    if (state === 'completed' || state === 'missing') {
+      this.completionStateCache.set(taskId, state);
+    }
+    this.plugin.debugLog(`[TodoistSyncAPI] Completion state for ${taskId}: ${state}`);
+    return state;
   }
 
   // Local-only lookup: no network requests, returns undefined if not found

--- a/src/api/syncApi.ts
+++ b/src/api/syncApi.ts
@@ -1096,6 +1096,15 @@ export class TodoistSyncAPI   {
     if (!restApi) return 'unknown';
 
     const resolvedId = (await this.resolveLegacyId('tasks', taskId)) || taskId;
+
+    // A pre-migration numeric ID that Todoist could not map to a current one is
+    // unaddressable, so a lookup by it would 404 and read as "deleted" for a task
+    // that may be perfectly alive under its new ID. Refuse to guess.
+    if (/^\d+$/.test(taskId) && resolvedId === taskId) {
+      this.plugin.debugLog(`[TodoistSyncAPI] ${taskId} is an unresolved legacy ID; completion state unknown`);
+      return 'unknown';
+    }
+
     const state = await restApi.getTaskCompletionState(resolvedId);
     // Only terminal verdicts are cached. 'active' means the absence was transient,
     // so caching it would hide a completion that happens later in the session, and

--- a/src/api/syncApi.ts
+++ b/src/api/syncApi.ts
@@ -315,6 +315,14 @@ export class TodoistSyncAPI   {
 		return await this.deviceManager.getClientHeader();
 	}
 
+  private async resolveLegacyId(objName: 'projects' | 'tasks' | 'sections', id?: string | null): Promise<string | undefined> {
+    if (!id) {
+      return undefined;
+    }
+
+    return await this.plugin.todoistRestAPI?.resolveId(objName, id);
+  }
+
 	async initializeSync(): Promise<void> {
 		// Route through incrementalSync lock so concurrent callers wait
 		if (this._syncRunning) {
@@ -448,13 +456,13 @@ export class TodoistSyncAPI   {
     		method: 'POST',
     		headers: {
     			'Authorization': `Bearer ${accessToken}`,
- 				'Content-Type': 'application/x-www-form-urlencoded',
+ 				'Content-Type': 'application/json',
  				'X-Todoist-Client': clientId
     		},
-    		body: new URLSearchParams({
+    		body: JSON.stringify({
     			sync_token: syncToken,
-    			resource_types: '["all"]'
-    		}).toString()
+    			resource_types: ['all'],
+    		}),
     	};
   
 	    	try {
@@ -514,12 +522,12 @@ export class TodoistSyncAPI   {
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${accessToken}`,
-          'Content-Type': 'application/x-www-form-urlencoded'
+          'Content-Type': 'application/json',
         },
-        body: new URLSearchParams({
-          sync_token: "*",
-          resource_types: '["user_plan_limits"]'
-        }).toString()
+        body: JSON.stringify({
+          sync_token: '*',
+          resource_types: ['user_plan_limits'],
+        }),
       };
     
       try {
@@ -557,15 +565,15 @@ export class TodoistSyncAPI   {
           method: 'POST',
           headers: {
             'Authorization': `Bearer ${accessToken}`,
-            'Content-Type': 'application/x-www-form-urlencoded'
+            'Content-Type': 'application/json',
           },
-          body: new URLSearchParams({ commands: JSON.stringify(commands) }).toString()
+          body: JSON.stringify({ commands }),
         };
-      
+
         try {
           const response = await requestUrl(options);
 		  this.assertSuccessfulResponse('updateUserTimezone', response);
-      
+
           const data = response.json;
           this.plugin.debugLog(data)
           return data;
@@ -791,12 +799,10 @@ export class TodoistSyncAPI   {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${accessToken}`,
- 		'Content-Type': 'application/x-www-form-urlencoded',
+ 		'Content-Type': 'application/json',
  		'X-Todoist-Client': clientId
       },
-      body: new URLSearchParams({
-        commands: JSON.stringify(commands)
-      }).toString()
+      body: JSON.stringify({ commands }),
     };
 
     try {
@@ -840,25 +846,25 @@ export class TodoistSyncAPI   {
     due?: { string?: string; date?: string; datetime?: string };
     priority?: number;
     description?: string;
-  }): Promise<{ id: string }> {
-    const tempId = this.generateTempId();
-    const command = {
-      type: 'item_add',
-      uuid: this.generateUUID(),
-      temp_id: tempId,
-      args: args
-    };
+    labels?: string[];
+  }): Promise<any> {
+    const todoistRestAPI = this.plugin.todoistRestAPI;
+    if (!todoistRestAPI) {
+      throw new Error('Todoist REST API is not initialized');
+    }
 
-    const result = await this.executeCommands([command]);
-    if (result && result.temp_id_mapping && result.temp_id_mapping[tempId]) {
-      return { id: result.temp_id_mapping[tempId] };
-    }
-    const cmdStatus = result?.sync_status?.[command.uuid];
-    if (cmdStatus && cmdStatus !== 'ok') {
-      const err = cmdStatus as { error?: string; error_code?: number };
-      throw new Error(`Failed to add task: ${err.error || JSON.stringify(cmdStatus)}`);
-    }
-    throw new Error(`Failed to add task: no temp_id_mapping in response. Response: ${JSON.stringify(result)}`);
+    const projectId = await this.resolveLegacyId('projects', args.project_id);
+    const parentId = await this.resolveLegacyId('tasks', args.parent_id);
+    return await todoistRestAPI.AddTask({
+      projectId: projectId || undefined,
+      content: args.content,
+      parentId,
+      dueDate: args.due?.date,
+      dueDatetime: args.due?.datetime,
+      labels: args.labels,
+      description: args.description,
+      priority: args.priority,
+    });
   }
 
   // Update task using Sync API
@@ -866,60 +872,61 @@ export class TodoistSyncAPI   {
     content?: string;
     description?: string;
     priority?: number;
-    due?: { string?: string; date?: string };
-  }): Promise<boolean> {
-    const command = {
-      type: 'item_update',
-      uuid: this.generateUUID(),
-      args: {
-        id: taskId,
-        ...args
-      }
-    };
+    labels?: string[];
+    parent_id?: string;
+    due?: { string?: string; date?: string; datetime?: string };
+  }): Promise<any> {
+    const todoistRestAPI = this.plugin.todoistRestAPI;
+    if (!todoistRestAPI) {
+      throw new Error('Todoist REST API is not initialized');
+    }
 
-    await this.executeCommands([command]);
-    return true;
+    const resolvedTaskId = await this.resolveLegacyId('tasks', taskId);
+    return await todoistRestAPI.UpdateTask(resolvedTaskId || taskId, {
+      content: args.content,
+      description: args.description,
+      labels: args.labels,
+      dueDate: args.due?.date,
+      dueDatetime: args.due?.datetime,
+      dueString: args.due?.string,
+      parentId: await this.resolveLegacyId('tasks', args.parent_id),
+      priority: args.priority,
+    });
   }
 
   // Close task using Sync API
   async closeTask(taskId: string): Promise<boolean> {
-    const command = {
-      type: 'item_close',
-      uuid: this.generateUUID(),
-      args: {
-        id: taskId
-      }
-    };
+    const todoistRestAPI = this.plugin.todoistRestAPI;
+    if (!todoistRestAPI) {
+      throw new Error('Todoist REST API is not initialized');
+    }
 
-    await this.executeCommands([command]);
-    return true;
+    const resolvedTaskId = await this.resolveLegacyId('tasks', taskId);
+    return await todoistRestAPI.CloseTask(resolvedTaskId || taskId);
   }
 
   // Reopen task using Sync API (item_uncomplete per official docs)
   async reopenTask(taskId: string): Promise<boolean> {
-    const command = {
-      type: 'item_uncomplete',
-      uuid: this.generateUUID(),
-      args: {
-        id: taskId
-      }
-    };
+    const todoistRestAPI = this.plugin.todoistRestAPI;
+    if (!todoistRestAPI) {
+      throw new Error('Todoist REST API is not initialized');
+    }
 
-    await this.executeCommands([command]);
-    return true;
+    const resolvedTaskId = await this.resolveLegacyId('tasks', taskId);
+    return await todoistRestAPI.OpenTask(resolvedTaskId || taskId);
   }
 
   // Compatible wrapper: AddTask
   async AddTask(task: {
     projectId: string;
     content: string;
-    parentId?: string;
+    parentId?: string | null;
     dueDate?: string;
     dueDatetime?: string;
     labels?: string[];
     description?: string;
     priority?: number;
-  }): Promise<{ id: string }> {
+  }): Promise<any> {
     const args: any = {
       content: task.content,
     };
@@ -963,7 +970,7 @@ export class TodoistSyncAPI   {
     dueString?: string;
     parentId?: string;
     priority?: number;
-  }): Promise<boolean> {
+  }): Promise<any> {
     const args: any = {};
 
     if (updates.content) args.content = updates.content;
@@ -1009,6 +1016,7 @@ export class TodoistSyncAPI   {
   // Compatible wrapper: GetTaskById
   async GetTaskById(taskId: string, options?: { allowNetworkRefresh?: boolean }): Promise<any> {
     try {
+      taskId = (await this.resolveLegacyId('tasks', taskId)) || taskId;
       const allowNetworkRefresh = options?.allowNetworkRefresh !== false;
 
       if (!this.syncData) {
@@ -1061,10 +1069,13 @@ export class TodoistSyncAPI   {
         this.syncData = await this.getAllResources(true);
       }
       let tasks = this.syncData?.items || [];
+      const resolvedProjectId = options?.projectId
+        ? await this.resolveLegacyId('projects', options.projectId)
+        : undefined;
 
       if (options) {
-        if (options.projectId) {
-          tasks = tasks.filter((t: any) => t.project_id === options.projectId);
+        if (resolvedProjectId) {
+          tasks = tasks.filter((t: any) => t.project_id === resolvedProjectId);
         }
         if (options.section_id) {
           tasks = tasks.filter((t: any) => t.section_id === options.section_id);
@@ -1087,6 +1098,7 @@ export class TodoistSyncAPI   {
   // Get project by ID from syncData
   async getProjectById(projectId: string): Promise<any> {
     try {
+      projectId = (await this.resolveLegacyId('projects', projectId)) || projectId;
       if (!this.syncData) {
         this.syncData = await this.getAllResources(true);
       }
@@ -1119,16 +1131,13 @@ export class TodoistSyncAPI   {
 
   // Delete task using Sync API
   async deleteTask(taskId: string): Promise<boolean> {
-    const command = {
-      type: 'item_delete',
-      uuid: this.generateUUID(),
-      args: {
-        id: taskId
-      }
-    };
+    const todoistRestAPI = this.plugin.todoistRestAPI;
+    if (!todoistRestAPI) {
+      throw new Error('Todoist REST API is not initialized');
+    }
 
-    await this.executeCommands([command]);
-    return true;
+    const resolvedTaskId = await this.resolveLegacyId('tasks', taskId);
+    return await todoistRestAPI.DeleteTask(resolvedTaskId || taskId);
   }
 
   /**

--- a/src/api/syncApi.ts
+++ b/src/api/syncApi.ts
@@ -323,6 +323,23 @@ export class TodoistSyncAPI   {
     return await this.plugin.todoistRestAPI?.resolveId(objName, id);
   }
 
+	// Waiters must be drained *after* the run completes, not captured before it:
+	// callers that join while a sync is in flight push themselves onto the queue
+	// during the run, and would otherwise stay pending until some later sync
+	// happened to drain them — hanging every `await incrementalSync()` and, with
+	// it, the sync lock its caller is holding.
+	private resolveSyncWaiters(): void {
+		for (const waiter of this._syncWaiters.splice(0)) {
+			waiter.resolve();
+		}
+	}
+
+	private rejectSyncWaiters(error: unknown): void {
+		for (const waiter of this._syncWaiters.splice(0)) {
+			waiter.reject(error);
+		}
+	}
+
 	async initializeSync(): Promise<void> {
 		// Route through incrementalSync lock so concurrent callers wait
 		if (this._syncRunning) {
@@ -333,15 +350,15 @@ export class TodoistSyncAPI   {
 		}
 		this._syncRunning = true;
 		this._syncDirty = false;
-		const waiters = this._syncWaiters.splice(0);
 		try {
 			const data = await this.getAllResources(true);
 			this.syncData = data;
 			await this.plugin.safeSettings?.update({ syncDataCache: data }, true);
 			this.plugin.debugLog('[TodoistSyncAPI] Sync initialized with full data and cached');
-			waiters.forEach(w => w.resolve());
+			// A full sync answers every waiter, including those that joined mid-run.
+			this.resolveSyncWaiters();
 		} catch (error) {
-			waiters.forEach(w => w.reject(error));
+			this.rejectSyncWaiters(error);
 			throw error;
 		} finally {
 			this._syncRunning = false;
@@ -363,7 +380,6 @@ export class TodoistSyncAPI   {
 
 		this._syncRunning = true;
 		this._syncDirty = false;
-		const waiters = this._syncWaiters.splice(0);
 		try {
 			do {
 				this._syncDirty = false;
@@ -381,10 +397,12 @@ export class TodoistSyncAPI   {
 				await this.plugin.safeSettings?.update({ syncDataCache: this.syncData }, true);
 				this.plugin.debugLog('[TodoistSyncAPI] Incremental sync completed and cached');
 			} while (this._syncDirty);
-			waiters.forEach(w => w.resolve());
+			// Loop condition guarantees anyone who joined mid-run got a fetch that
+			// started after their change landed.
+			this.resolveSyncWaiters();
 		} catch (error) {
 			console.error('[TodoistSyncAPI] Incremental sync failed:', error);
-			waiters.forEach(w => w.reject(error));
+			this.rejectSyncWaiters(error);
 			throw error;
 		} finally {
 			this._syncRunning = false;

--- a/src/api/syncApi.ts
+++ b/src/api/syncApi.ts
@@ -46,6 +46,7 @@ export class TodoistSyncAPI   {
 	private syncData: Record<string, any> | null = null;
 	// taskId → what a direct lookup said about a task missing from syncData.
 	private completionStateCache = new Map<string, 'completed' | 'missing'>();
+
 	// API-level sync lock — prevents concurrent incrementalSync/initializeSync
 	private _syncRunning = false;
 	private _syncDirty = false;
@@ -1050,6 +1051,15 @@ export class TodoistSyncAPI   {
       if (found) return found;
 
       if (!allowNetworkRefresh) {
+        return undefined;
+      }
+
+      // A task we already know is completed or deleted will never come back in a
+      // sync, so refreshing for it is a guaranteed-useless round trip. Without
+      // this, every settled task costs one full sync per pass that touches it.
+      const knownTerminal = this.completionStateCache.get(taskId);
+      if (knownTerminal) {
+        this.plugin.debugLog(`[TodoistSyncAPI] Skipping refresh for ${taskId}: known ${knownTerminal}`);
         return undefined;
       }
 

--- a/src/data/cache.ts
+++ b/src/data/cache.ts
@@ -568,6 +568,7 @@ export class CacheOperation   {
 
         for (const { taskId, filePath } of candidates) {
             const state = states.get(taskId);
+            this.plugin.debugLog(`[reclassifyMissingTaskIssues] ${taskId} (${filePath}): ${state}`);
 
             if (state === 'completed') {
                 // Done in Todoist. Reflect that in the vault, then record it as a
@@ -599,10 +600,29 @@ export class CacheOperation   {
             }
 
             if (state === 'missing') {
+                // Todoist confirms it is gone. Keep the issue, but record that it
+                // was actually checked — otherwise this looks identical in the task
+                // manager to an entry the repair never got to.
+                await this.upsertTaskIssue(taskId, 'todoist_task_missing', {
+                    state: 'open',
+                    severity: 'high',
+                    source: 'runtime',
+                    details: `Confirmed deleted in Todoist (checked ${new Date().toLocaleString()}). The vault still has this task.`,
+                    manualAction: 'Delete to unbind it here; with Full Vault Sync on it is then re-created in Todoist as a new task.',
+                }, false);
                 result.stillMissing++;
                 continue;
             }
 
+            // Could not ask Todoist — network, auth, or rate limit. Say so, rather
+            // than leaving the original "no longer exists" claim standing unchecked.
+            await this.upsertTaskIssue(taskId, 'todoist_task_missing', {
+                state: 'open',
+                severity: 'medium',
+                source: 'runtime',
+                details: `Could not reach Todoist to check this task (last tried ${new Date().toLocaleString()}).`,
+                manualAction: 'Run Safe Repair again — no decision has been made about this task yet.',
+            }, false);
             result.unresolved++;
         }
 

--- a/src/data/cache.ts
+++ b/src/data/cache.ts
@@ -599,6 +599,13 @@ export class CacheOperation   {
                     syncEnabled: true,
                     issues: undefined,
                     createdAt: previous?.createdAt ?? Date.now(),
+                    // Deliberately not carried over: the recorded revision belongs
+                    // to the old id, so keeping it would read as "Todoist changed
+                    // behind our back" on this task's very next edit. Undefined
+                    // means "no basis for comparison", and the next sync records
+                    // the real one.
+                    updated_at: undefined,
+                    note_count: undefined,
                 };
                 await this.plugin.safeSettings?.update({ taskFileMapping: mapping }, false);
 

--- a/src/data/cache.ts
+++ b/src/data/cache.ts
@@ -990,7 +990,7 @@ export class CacheOperation   {
     // ==========================================================================================
 
     // DEPRECATED: Using syncData from Todoist API instead - no longer needed
-    loadTasksFromCache() {
+    loadTasksFromCache(): any[] {
         return [];
     }
 

--- a/src/data/cache.ts
+++ b/src/data/cache.ts
@@ -313,7 +313,7 @@ export class CacheOperation   {
      * @param taskId - Todoist 任务 ID
      * @returns 文件路径、状态和同步开关，如果不存在则返回 null
      */
-    getTaskFileMapping(taskId: string): { filePath: string; status?: string; syncEnabled?: boolean; updated_at?: string; note_count?: number; issues?: Record<string, unknown> } | null {
+    getTaskFileMapping(taskId: string): { filePath: string; status?: string; syncEnabled?: boolean; updated_at?: string; note_count?: number; createdAt?: number; issues?: Record<string, unknown> } | null {
         return this.plugin.settings.taskFileMapping[taskId] ?? null;
     }
 
@@ -336,7 +336,13 @@ export class CacheOperation   {
         const existing = mapping[taskId];
         const nextStatus = deriveTaskStatusFromIssueEntries(existing?.issues as TaskIssueRecord | undefined, status);
         const nextSyncEnabled = nextStatus === 'active' ? syncEnabled : false;
-        mapping[taskId] = { ...existing, filePath, status: nextStatus, syncEnabled: nextSyncEnabled };
+        mapping[taskId] = {
+            ...existing,
+            filePath,
+            status: nextStatus,
+            syncEnabled: nextSyncEnabled,
+            createdAt: existing?.createdAt ?? Date.now(),
+        };
         await this.plugin.safeSettings?.update({ taskFileMapping: mapping });
     }
 

--- a/src/data/cache.ts
+++ b/src/data/cache.ts
@@ -517,6 +517,103 @@ export class CacheOperation   {
         return changed;
     }
 
+    /**
+     * Re-judge every task currently flagged "missing in Todoist" by asking Todoist
+     * about it directly.
+     *
+     * These issues were raised on the assumption that absence from the sync data
+     * means deletion. It does not: a completed task drops out of /api/v1/sync
+     * entirely, so a routine tick-off in Todoist produced an issue demanding
+     * manual attention. Vaults carry hundreds of these.
+     *
+     * Deleting them is the wrong answer, and with Full Vault Sync on it is worse
+     * than a no-op: the delete unbinds the line, the next pass re-tags it, and the
+     * task comes back as a brand new open task in Todoist.
+     */
+    async reclassifyMissingTaskIssues(
+        onProgress?: (done: number, total: number) => void
+    ): Promise<{ completed: number; restored: number; stillMissing: number; unresolved: number }> {
+        const todoistSyncAPI = this.plugin.todoistSyncAPI;
+        const result = { completed: 0, restored: 0, stillMissing: 0, unresolved: 0 };
+        if (!todoistSyncAPI) return result;
+
+        const candidates = Object.entries(this.plugin.settings.taskFileMapping)
+            .filter(([, entry]) => {
+                const issue = (entry.issues as Record<string, { state?: string }> | undefined)?.todoist_task_missing;
+                return issue?.state === 'open';
+            })
+            .map(([taskId, entry]) => ({ taskId, filePath: entry.filePath }));
+
+        if (candidates.length === 0) return result;
+
+        // Look the states up concurrently — they are read-only — but apply the
+        // mapping changes one at a time, since each is a read-modify-write of the
+        // whole settings object.
+        const CONCURRENCY = 4;
+        const states = new Map<string, string>();
+        let done = 0;
+        for (let i = 0; i < candidates.length; i += CONCURRENCY) {
+            const batch = candidates.slice(i, i + CONCURRENCY);
+            await Promise.all(batch.map(async ({ taskId }) => {
+                try {
+                    states.set(taskId, await todoistSyncAPI.GetTaskCompletionState(taskId));
+                } catch (error) {
+                    console.error(`[reclassifyMissingTaskIssues] Lookup failed for ${taskId}:`, error);
+                    states.set(taskId, 'unknown');
+                }
+                done++;
+                onProgress?.(done, candidates.length);
+            }));
+        }
+
+        for (const { taskId, filePath } of candidates) {
+            const state = states.get(taskId);
+
+            if (state === 'completed') {
+                // Done in Todoist. Reflect that in the vault, then record it as a
+                // settled non-active task rather than a problem. The issue must be
+                // resolved first: status is derived from the open issues.
+                try {
+                    await this.plugin.fileOperation?.completeTaskInTheFile(taskId);
+                } catch (error) {
+                    console.warn(`[reclassifyMissingTaskIssues] Could not tick ${taskId} in the vault:`, error);
+                }
+                await this.resolveTaskIssues(taskId, (issueType) => issueType === 'todoist_task_missing', false);
+                await this.upsertTaskIssue(taskId, 'task_marked_nonactive', {
+                    state: 'open',
+                    severity: 'low',
+                    source: 'runtime',
+                    details: 'Task was completed in Todoist.',
+                }, false);
+                result.completed++;
+                continue;
+            }
+
+            if (state === 'active') {
+                // Todoist has it, open. The task was never missing — the sync data
+                // was simply stale when it was flagged. Put it back into sync.
+                await this.resolveTaskIssues(taskId, (issueType) => issueType === 'todoist_task_missing', false);
+                await this.setTaskFileMapping(taskId, filePath, 'active', true);
+                result.restored++;
+                continue;
+            }
+
+            if (state === 'missing') {
+                result.stillMissing++;
+                continue;
+            }
+
+            result.unresolved++;
+        }
+
+        await this.plugin.safeSettings?.update({ taskFileMapping: this.plugin.settings.taskFileMapping }, true);
+        this.plugin.logOperation?.log(
+            'DATABASE_CHECKED',
+            `Re-checked ${candidates.length} missing-task issues: ${result.completed} completed, ${result.restored} restored, ${result.stillMissing} confirmed deleted, ${result.unresolved} unresolved`
+        );
+        return result;
+    }
+
     async applyMatchFirstAutoRepairs(resultIssues: DatabaseCheckIssueLike[], shouldSave = true): Promise<MatchFirstAutoRepairResult> {
         const taskFileMapping = { ...this.plugin.settings.taskFileMapping };
         const touchedTaskIds = new Set<string>();

--- a/src/data/cache.ts
+++ b/src/data/cache.ts
@@ -532,19 +532,87 @@ export class CacheOperation   {
      */
     async reclassifyMissingTaskIssues(
         onProgress?: (done: number, total: number) => void
-    ): Promise<{ completed: number; restored: number; stillMissing: number; unresolved: number }> {
+    ): Promise<{ migrated: number; completed: number; restored: number; stillMissing: number; unresolved: number }> {
         const todoistSyncAPI = this.plugin.todoistSyncAPI;
-        const result = { completed: 0, restored: 0, stillMissing: 0, unresolved: 0 };
+        const result = { migrated: 0, completed: 0, restored: 0, stillMissing: 0, unresolved: 0 };
         if (!todoistSyncAPI) return result;
 
-        const candidates = Object.entries(this.plugin.settings.taskFileMapping)
+        const allCandidates = Object.entries(this.plugin.settings.taskFileMapping)
             .filter(([, entry]) => {
                 const issue = (entry.issues as Record<string, { state?: string }> | undefined)?.todoist_task_missing;
                 return issue?.state === 'open';
             })
             .map(([taskId, entry]) => ({ taskId, filePath: entry.filePath }));
 
-        if (candidates.length === 0) return result;
+        if (allCandidates.length === 0) return result;
+
+        // A task carrying a pre-migration numeric Todoist ID is absent from the
+        // sync data simply because that data is keyed by the new IDs — the task is
+        // alive and well under a new one. Migrate those before concluding anything:
+        // looking one up by its old ID answers "missing", which would invite the
+        // user to delete a task that still exists.
+        const handled = new Set<string>();
+        const legacyCandidates = allCandidates.filter(({ taskId }) => /^\d+$/.test(taskId));
+        const restApi = this.plugin.todoistRestAPI;
+        const fileOperation = this.plugin.fileOperation;
+
+        if (legacyCandidates.length > 0 && restApi && fileOperation) {
+            let resolvedIds: Record<string, string> = {};
+            try {
+                resolvedIds = await restApi.resolveIds('tasks', legacyCandidates.map(({ taskId }) => taskId));
+            } catch (error) {
+                console.error('[reclassifyMissingTaskIssues] Legacy ID resolution failed:', error);
+            }
+
+            for (const { taskId, filePath } of legacyCandidates) {
+                const newId = resolvedIds[taskId];
+                if (!newId || newId === taskId) {
+                    // Todoist has no new ID for it. It may be genuinely gone, but an
+                    // unaddressable ID is not evidence of that, so say exactly that.
+                    await this.upsertTaskIssue(taskId, 'todoist_task_missing', {
+                        state: 'open',
+                        severity: 'medium',
+                        source: 'runtime',
+                        details: `Task uses a pre-migration Todoist ID (${taskId}) that Todoist could not map to a current one.`,
+                        manualAction: 'Open the task link: if Todoist still shows the task, run Safe Repair again once online.',
+                    }, false);
+                    handled.add(taskId);
+                    result.unresolved++;
+                    continue;
+                }
+
+                const vaultUpdated = await fileOperation.updateTaskIdInVault(filePath, taskId, newId);
+                if (!vaultUpdated) {
+                    this.plugin.debugLog(`[reclassifyMissingTaskIssues] Could not rewrite ${taskId} -> ${newId} in ${filePath}`);
+                    continue;
+                }
+
+                // Move the mapping onto the new ID, keeping the entry's history and
+                // dropping the issue that was only ever about the old ID.
+                const mapping = { ...this.plugin.settings.taskFileMapping };
+                const previous = mapping[taskId];
+                delete mapping[taskId];
+                mapping[newId] = {
+                    ...previous,
+                    filePath,
+                    status: 'active',
+                    syncEnabled: true,
+                    issues: undefined,
+                    createdAt: previous?.createdAt ?? Date.now(),
+                };
+                await this.plugin.safeSettings?.update({ taskFileMapping: mapping }, false);
+
+                this.plugin.logOperation?.log('FILE_TASK_ID_UPDATED', `Migrated legacy task ID ${taskId} -> ${newId}`, filePath, newId);
+                handled.add(taskId);
+                result.migrated++;
+            }
+        }
+
+        const candidates = allCandidates.filter(({ taskId }) => !handled.has(taskId));
+        if (candidates.length === 0) {
+            await this.plugin.safeSettings?.update({ taskFileMapping: this.plugin.settings.taskFileMapping }, true);
+            return result;
+        }
 
         // Look the states up concurrently — they are read-only — but apply the
         // mapping changes one at a time, since each is a read-modify-write of the
@@ -629,7 +697,7 @@ export class CacheOperation   {
         await this.plugin.safeSettings?.update({ taskFileMapping: this.plugin.settings.taskFileMapping }, true);
         this.plugin.logOperation?.log(
             'DATABASE_CHECKED',
-            `Re-checked ${candidates.length} missing-task issues: ${result.completed} completed, ${result.restored} restored, ${result.stillMissing} confirmed deleted, ${result.unresolved} unresolved`
+            `Re-checked ${allCandidates.length} missing-task issues: ${result.migrated} legacy IDs migrated, ${result.completed} completed, ${result.restored} restored, ${result.stillMissing} confirmed deleted, ${result.unresolved} unresolved`
         );
         return result;
     }

--- a/src/data/databaseChecker.ts
+++ b/src/data/databaseChecker.ts
@@ -199,19 +199,6 @@ export class DatabaseChecker {
         }
     }
 
-	private async confirmTodoistTaskMissing(taskId: string): Promise<boolean> {
-		const todoistSyncAPI = this.plugin.todoistSyncAPI;
-		if (!todoistSyncAPI) return false;
-
-		try {
-			const task = await todoistSyncAPI.GetTaskById(taskId, { allowNetworkRefresh: false });
-			return !task;
-		} catch (error) {
-			console.error(`[DatabaseChecker] confirmTodoistTaskMissing failed for ${taskId}:`, error);
-			return false;
-		}
-	}
-
     /**
      * 主检查方法 - 执行完整的数据库一致性检查
      * 
@@ -777,28 +764,22 @@ export class DatabaseChecker {
                 }
 
                 if (vaultTask.isCompleted) {
-                    const missingConfirmed = await this.confirmTodoistTaskMissing(taskId);
-                    if (missingConfirmed) {
-                        emitIssue({
-                            type: 'task_marked_nonactive',
-                            filePath: vaultTask.filePath,
-                            taskId,
-                            lineNumber: vaultTask.lineNumber,
-                            details: 'Task is completed in Vault and confirmed missing in Todoist',
-                            obsidianContent: vaultTask.content,
-                            obsidianStatus: vaultTask.isCompleted,
-                        });
-                    } else {
-                        emitIssue({
-                            type: 'issue_source_unconfirmed',
-                            filePath: vaultTask.filePath,
-                            taskId,
-                            lineNumber: vaultTask.lineNumber,
-                            details: 'Task appears missing in Todoist cache but could not be confirmed via direct lookup',
-                            obsidianContent: vaultTask.content,
-                            obsidianStatus: vaultTask.isCompleted,
-                        });
-                    }
+                    // Completed here and absent from the sync data is the normal end
+                    // state, not a discrepancy: /api/v1/sync only returns active
+                    // items, so every task ever completed leaves it. This used to be
+                    // put to a direct lookup, and anything that lookup could not
+                    // confirm — including every failure of it — was escalated to
+                    // "source unconfirmed", turning ordinary finished tasks into
+                    // problems demanding attention.
+                    emitIssue({
+                        type: 'task_marked_nonactive',
+                        filePath: vaultTask.filePath,
+                        taskId,
+                        lineNumber: vaultTask.lineNumber,
+                        details: 'Task is completed in Vault and no longer in the Todoist active set',
+                        obsidianContent: vaultTask.content,
+                        obsidianStatus: vaultTask.isCompleted,
+                    });
                 } else {
                     emitIssue({
                         type: 'todoist_task_missing',

--- a/src/data/databaseChecker.ts
+++ b/src/data/databaseChecker.ts
@@ -122,6 +122,13 @@ export interface TodoistTask {
 export interface DatabaseCheckResult {
     success: boolean;               // 检查是否通过（无问题）
     totalIssues: number;            // 问题总数
+    /**
+     * Issues that actually need a decision. Excludes settled ones — a task
+     * completed in the vault and gone from Todoist's active set is a normal end
+     * state, not something to fix, and counting it made every launch report
+     * "database issues" for a healthy vault.
+     */
+    actionableIssues: number;
     issues: DatabaseCheckIssue[];   // 问题列表
     summary: {                      // 统计摘要
         // taskFileMapping 相关
@@ -335,13 +342,15 @@ export class DatabaseChecker {
 
             // 计算问题总数
             const totalIssues = Object.values(summary).reduce((a, b) => a + b, 0);
+            const actionableIssues = totalIssues - summary.taskNonActive;
             // 记录日志
-            this.plugin.logOperation?.log('DATABASE_CHECKED', `Database check completed: ${totalIssues} issues found`);
+            this.plugin.logOperation?.log('DATABASE_CHECKED', `Database check completed: ${actionableIssues} issues needing action, ${summary.taskNonActive} settled`);
 
             // ====== 生成报告 ======
             const reportPath = await this.generateReport({
-                success: totalIssues === 0,
+                success: actionableIssues === 0,
                 totalIssues,
+                actionableIssues,
                 issues,
                 summary,
                 step1Stats,
@@ -350,8 +359,9 @@ export class DatabaseChecker {
 
             // 返回检查结果
             return {
-                success: totalIssues === 0,
+                success: actionableIssues === 0,
                 totalIssues,
+                actionableIssues,
                 issues,
                 summary,
                 reportPath,
@@ -365,6 +375,7 @@ export class DatabaseChecker {
             return {
                 success: false,
                 totalIssues: 0,
+                actionableIssues: 0,
                 issues: [{
                     type: 'issue_unclassified',
                     details: `Database check failed: ${(error as Error).message}`

--- a/src/data/databaseChecker.ts
+++ b/src/data/databaseChecker.ts
@@ -452,6 +452,21 @@ export class DatabaseChecker {
             duplicateTask: 0
         };
 
+        // Only fields that some direction actually syncs are worth comparing. With
+        // Obsidian creating tasks and Todoist owning them afterwards, a differing
+        // title or label is the expected steady state, not a fault — reporting it
+        // buries the real problems under one entry per task worked on in Todoist.
+        const pushesFieldEdits = this.plugin.settings.obsidianToTodoistScope === 'full';
+        const pullsFieldEdits = this.plugin.settings.todoistToObsidianEnabled
+            && this.plugin.settings.todoistToObsidianScope === 'full';
+        const pullsDueDate = this.plugin.settings.todoistToObsidianEnabled;
+        const watches = {
+            content: pushesFieldEdits || pullsFieldEdits,
+            dueDate: pushesFieldEdits || pullsDueDate,
+            priority: pushesFieldEdits || pullsFieldEdits,
+            labels: pushesFieldEdits || pullsFieldEdits,
+        };
+
         const vaultFiles = new Set(this.app.vault.getFiles().map(file => file.path));
 
         let vaultWithMapping = 0;
@@ -624,7 +639,7 @@ export class DatabaseChecker {
 
                 let hasSemanticMismatch = false;
 
-                if (!taskParser.taskContentCompare(vaultTask, todoistTask)) {
+                if (watches.content && !taskParser.taskContentCompare(vaultTask, todoistTask)) {
                     emitIssue({
                         type: 'sync_content_mismatch',
                         filePath: vaultTask.filePath,
@@ -653,7 +668,7 @@ export class DatabaseChecker {
 
                 const vaultDueDate = vaultTask.dueDate || '';
                 const todoistDueDate = todoistTask.dueDate || '';
-                if (!taskParser.compareTaskDueDate(vaultTask, todoistTask)) {
+                if (watches.dueDate && !taskParser.compareTaskDueDate(vaultTask, todoistTask)) {
                     emitIssue({
                         type: 'sync_due_mismatch',
                         filePath: vaultTask.filePath,
@@ -668,7 +683,7 @@ export class DatabaseChecker {
 
                 const vaultPriority = vaultTask.priority || 1;
                 const todoistPriority = todoistTask.priority || 1;
-                if (!taskParser.taskPriorityCompare(vaultTask, todoistTask)) {
+                if (watches.priority && !taskParser.taskPriorityCompare(vaultTask, todoistTask)) {
                     emitIssue({
                         type: 'sync_priority_mismatch',
                         filePath: vaultTask.filePath,
@@ -683,7 +698,7 @@ export class DatabaseChecker {
 
                 const obsidianLabels = taskParser.normalizeLabelsForCompare(vaultTask.labels);
                 const todoistLabels = taskParser.normalizeLabelsForCompare(todoistTask.labels);
-                if (!taskParser.taskTagCompare(vaultTask, todoistTask)) {
+                if (watches.labels && !taskParser.taskTagCompare(vaultTask, todoistTask)) {
                     emitIssue({
                         type: 'sync_labels_mismatch',
                         filePath: vaultTask.filePath,

--- a/src/data/taskContent.ts
+++ b/src/data/taskContent.ts
@@ -1,0 +1,62 @@
+/**
+ * Reducing a vault task line to the text that is compared against Todoist.
+ *
+ * This is the comparator behind every "did the task change?" decision, so a
+ * fragment left behind here — a second link, a stray id block — reads as an edit
+ * the user never made, and produces a conflict on a line nobody touched.
+ *
+ * Kept free of imports so it can be unit-tested directly.
+ */
+
+const DUE_DATE_EMOJI = '🗓️|📅|📆|🗓';
+
+/**
+ * All markers are stripped globally and case-insensitively — Todoist's legacy
+ * URL is `showTask`, camel-cased, which a lowercase pattern silently missed,
+ * leaving the whole link in the compared text.
+ *
+ * All markers are stripped globally. A line can legitimately carry more than one
+ * of several of these (older versions of the plugin could write a second link and
+ * id block onto the same line), and a non-global strip left the extras in the
+ * compared text.
+ */
+const STRIP_PATTERNS: RegExp[] = [
+    // %%[todoist_id:: abc123]%%
+    /%%\[\w+::\s*\w+\]%%/g,
+    // [link](https://todoist.com/showtask?id=123)
+    /\[([^\]]*)\]\(https?:\/\/todoist\.com\/showtask\?id=\S*\)/gi,
+    // [link](https://app.todoist.com/app/task/abc123)
+    /\[([^\]]*)\]\(https?:\/\/app\.todoist\.com\/app\/task\/\S*\)/gi,
+    // [link](https://todoist.com/app/task/abc123) — old domain, new path
+    /\[([^\]]*)\]\(https?:\/\/todoist\.com\/app\/task\/\S*\)/gi,
+    // [link](todoist://task?id=abc123)
+    /\[([^\]]*)\]\(todoist:\/\/task\?id=\S*\)/gi,
+    // A bare task URL, which older builds and other plugins wrote without markdown
+    /(?:^|\s)(?:https?:\/\/(?:app\.)?todoist\.com\/(?:app\/task\/|showtask\?id=)|todoist:\/\/task\?id=)\S+/gi,
+];
+
+const REMOVE_PRIORITY = /\s!!([1-4])\s/g;
+const REMOVE_TAGS = /#[\w一-龥-]+/g;
+const REMOVE_DUE_DATE = new RegExp(`(${DUE_DATE_EMOJI})\\s?\\d{4}-\\d{2}-\\d{2}`, 'g');
+const REMOVE_CHECKBOX = /^(-|\*)\s+\[(x|X| )\]\s/;
+const REMOVE_CHECKBOX_WITH_INDENTATION = /^([ \t]*)?(-|\*)\s+\[(x|X| )\]\s/;
+const TRIM_EDGES = /^\s+|\s+$/g;
+
+/**
+ * The task text as Todoist stores it: no checkbox, tags, due date, priority,
+ * links or plugin metadata.
+ */
+export function stripTaskContent(lineText: string): string {
+    let content = lineText;
+    for (const pattern of STRIP_PATTERNS) {
+        content = content.replace(pattern, '');
+    }
+
+    return content
+        .replace(REMOVE_PRIORITY, ' ')
+        .replace(REMOVE_TAGS, '')
+        .replace(REMOVE_DUE_DATE, '')
+        .replace(REMOVE_CHECKBOX, '')
+        .replace(REMOVE_CHECKBOX_WITH_INDENTATION, '')
+        .replace(TRIM_EDGES, '');
+}

--- a/src/data/taskParser.ts
+++ b/src/data/taskParser.ts
@@ -1,4 +1,5 @@
 import { App} from 'obsidian';
+import { stripTaskContent } from './taskContent';
 import UltimateTodoistSyncForObsidian from "../../main";
 
 
@@ -330,18 +331,9 @@ export class TaskParser   {
   
   
     getTaskContentFromLineText(lineText:string) {
-        const TaskContent = lineText.replace(REGEX.TASK_CONTENT.REMOVE_INLINE_METADATA,"")
-                                    .replace(REGEX.TASK_CONTENT.REMOVE_TODOIST_LINK_OLD,"")  // 旧格式: todoist.com/showtask?id=xxx
-                                    .replace(REGEX.TASK_CONTENT.REMOVE_TODOIST_LINK_NEW,"")  // 新格式: app.todoist.com/app/task/xxx
-                                    .replace(REGEX.TASK_CONTENT.REMOVE_TODOIST_LINK_OLD_DOMAIN_NEW_PATH,"")
-                                    .replace(REGEX.TASK_CONTENT.REMOVE_TODOIST_LINK_APP_URI,"")
-                                    .replace(REGEX.TASK_CONTENT.REMOVE_PRIORITY," ") //priority 前后必须都有空格，
-                                    .replace(REGEX.TASK_CONTENT.REMOVE_TAGS,"")
-                                    .replace(REGEX.TASK_CONTENT.REMOVE_DATE,"")
-                                    .replace(REGEX.TASK_CONTENT.REMOVE_CHECKBOX,"")
-                                    .replace(REGEX.TASK_CONTENT.REMOVE_CHECKBOX_WITH_INDENTATION,"")
-                                    .replace(REGEX.TASK_CONTENT.REMOVE_SPACE,"")
-        return(TaskContent)
+        // Implemented in taskContent.ts, where it is unit-tested: this is the
+        // comparator behind every "did the task change?" decision.
+        return stripTaskContent(lineText)
     }
   
   

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -370,7 +370,7 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
                 reverseSyncWarningEl.textContent = '⚠️ Warning: in "Everything" scope, pulls rewrite the task line — tag order and spacing are normalised, and text you edited in Obsidian can be overwritten by the Todoist version. Back up your vault before relying on it.';
             } else if (enabled) {
                 reverseSyncWarningEl.style.cssText = 'margin: 6px 0 12px 0;';
-                reverseSyncWarningEl.textContent = 'Pulling completion status only: a task ticked in Todoist gets ticked in your vault, and nothing else on the line is touched.';
+                reverseSyncWarningEl.textContent = 'Pulling completion and due date: a task ticked or re-dated in Todoist is updated in your vault, and nothing else on the line is touched. Content, priority and labels stay owned by Obsidian — changing those in Todoist will be overwritten.';
             } else {
                 reverseSyncWarningEl.style.cssText = 'margin: 6px 0 12px 0;';
                 reverseSyncWarningEl.textContent = 'Changes made in Todoist are not applied to your vault. Note that with this off, a task edited in Todoist keeps its Obsidian version — the next edit here pushes over it.';
@@ -393,16 +393,16 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
 
         new Setting(containerEl)
             .setName('Reverse sync scope')
-            .setDesc('Completion only: tick/untick the checkbox, leaving the rest of the line alone. Everything: also apply content, due date, priority and labels, and append Todoist comments as sub-items.')
+            .setDesc('Completion and due date: tick/untick the checkbox and update the date, leaving the rest of the line alone. Everything: also apply content, priority and labels, and append Todoist comments as sub-items — note that fields left out here are owned by Obsidian, so changing them in Todoist gets overwritten on the next push.')
             .addDropdown(dropdown =>
                 dropdown
-                    .addOption('status', 'Completion only (recommended)')
-                    .addOption('full', 'Everything (content, due date, priority, labels, notes)')
+                    .addOption('status', 'Completion and due date (recommended)')
+                    .addOption('full', 'Everything (also content, priority, labels, notes)')
                     .setValue(this.plugin.settings.todoistToObsidianScope)
                     .onChange(async (value) => {
                         await this.plugin.safeSettings?.update({ todoistToObsidianScope: value as 'status' | 'full' }, true);
                         updateReverseSyncWarning();
-                        new Notice(`Reverse sync scope: ${value === 'full' ? 'everything' : 'completion only'}`);
+                        new Notice(`Reverse sync scope: ${value === 'full' ? 'everything' : 'completion and due date'}`);
                     })
             );
 

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -44,6 +44,12 @@ export interface UltimateTodoistSyncSettings {
     useAppURI: boolean;
     syncEnabled: boolean;
     obsidianToTodoistEnabled: boolean;
+    /**
+     * How much of a vault edit is pushed to Todoist after the task exists.
+     * 'create-and-complete' suits the common workflow where tasks are captured in
+     * Obsidian and then worked on in Todoist, which makes Todoist authoritative.
+     */
+    obsidianToTodoistScope: 'create-and-complete' | 'full';
     todoistToObsidianEnabled: boolean;
     /** What a Todoist→Obsidian pull is allowed to change in the vault. */
     todoistToObsidianScope: 'status' | 'full';
@@ -78,6 +84,7 @@ export const DEFAULT_SETTINGS: UltimateTodoistSyncSettings = {
     useAppURI: true,
     syncEnabled: true,
     obsidianToTodoistEnabled: true,
+    obsidianToTodoistScope: 'full',
     todoistToObsidianEnabled: false,
     todoistToObsidianScope: 'status',
     lastDatabaseCheckTime: null,
@@ -356,6 +363,22 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
                         await this.plugin.safeSettings?.update({ obsidianToTodoistEnabled: value }, true);
                         updateSyncStatus();
                         new Notice(`Obsidian → Todoist ${value ? 'enabled' : 'disabled'}`);
+                    })
+            );
+
+        new Setting(containerEl)
+            .setName('Forward sync scope')
+            .setDesc('Everything: keep Todoist matching the vault line — edits to the text, due date, priority and labels are pushed, and removing the line deletes the task. Create and complete: send new tasks and completion only, leaving everything else to Todoist. Choose the latter if you capture tasks in Obsidian and then work on them in Todoist, since a vault line that has drifted will otherwise overwrite what you did there.')
+            .addDropdown(dropdown =>
+                dropdown
+                    .addOption('full', 'Everything (text, due date, priority, labels, deletions)')
+                    .addOption('create-and-complete', 'Create and complete only (Todoist owns the rest)')
+                    .setValue(this.plugin.settings.obsidianToTodoistScope)
+                    .onChange(async (value) => {
+                        await this.plugin.safeSettings?.update({ obsidianToTodoistScope: value as 'create-and-complete' | 'full' }, true);
+                        new Notice(value === 'full'
+                            ? 'Forward sync: pushing every field'
+                            : 'Forward sync: new tasks and completion only');
                     })
             );
 

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -45,6 +45,8 @@ export interface UltimateTodoistSyncSettings {
     syncEnabled: boolean;
     obsidianToTodoistEnabled: boolean;
     todoistToObsidianEnabled: boolean;
+    /** What a Todoist→Obsidian pull is allowed to change in the vault. */
+    todoistToObsidianScope: 'status' | 'full';
     lastDatabaseCheckTime: number | null;
     syncDataCache: Record<string, any> | null;
     enableLog: boolean;
@@ -77,6 +79,7 @@ export const DEFAULT_SETTINGS: UltimateTodoistSyncSettings = {
     syncEnabled: true,
     obsidianToTodoistEnabled: true,
     todoistToObsidianEnabled: false,
+    todoistToObsidianScope: 'status',
     lastDatabaseCheckTime: null,
     syncDataCache: null,
     enableLog: true,
@@ -356,22 +359,55 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
                     })
             );
 
+        // Created after the two settings below so it renders underneath them.
+        let reverseSyncWarningEl: HTMLElement;
+        const updateReverseSyncWarning = () => {
+            if (!reverseSyncWarningEl) return;
+            const enabled = this.plugin.settings.todoistToObsidianEnabled;
+            const full = this.plugin.settings.todoistToObsidianScope === 'full';
+            if (enabled && full) {
+                reverseSyncWarningEl.style.cssText = 'color: var(--text-error); font-weight: 600; margin: 6px 0 12px 0;';
+                reverseSyncWarningEl.textContent = '⚠️ Warning: in "Everything" scope, pulls rewrite the task line — tag order and spacing are normalised, and text you edited in Obsidian can be overwritten by the Todoist version. Back up your vault before relying on it.';
+            } else if (enabled) {
+                reverseSyncWarningEl.style.cssText = 'margin: 6px 0 12px 0;';
+                reverseSyncWarningEl.textContent = 'Pulling completion status only: a task ticked in Todoist gets ticked in your vault, and nothing else on the line is touched.';
+            } else {
+                reverseSyncWarningEl.style.cssText = 'margin: 6px 0 12px 0;';
+                reverseSyncWarningEl.textContent = 'Changes made in Todoist are not applied to your vault. Note that with this off, a task edited in Todoist keeps its Obsidian version — the next edit here pushes over it.';
+            }
+        };
+
         new Setting(containerEl)
             .setName('Todoist → Obsidian')
-            .setDesc('⚠️ Reverse sync (Todoist → Obsidian) currently has known bugs and is disabled by default. Enabling is NOT recommended.')
+            .setDesc('Apply changes made in Todoist to your vault. Use the scope below to choose what a pull is allowed to change.')
             .addToggle(component =>
                 component
                     .setValue(this.plugin.settings.todoistToObsidianEnabled)
                     .onChange(async (value) => {
                         await this.plugin.safeSettings?.update({ todoistToObsidianEnabled: value }, true);
                         updateSyncStatus();
+                        updateReverseSyncWarning();
                         new Notice(`Todoist → Obsidian ${value ? 'enabled' : 'disabled'}`);
                     })
             );
 
-        const reverseSyncWarningEl = containerEl.createEl('div', { cls: 'setting-item-description' });
-        reverseSyncWarningEl.style.cssText = 'color: var(--text-error); font-weight: 600; margin: 6px 0 12px 0;';
-        reverseSyncWarningEl.textContent = '⚠️ Warning: Reverse sync may incorrectly overwrite vault data. Keep this switch OFF unless you are actively testing.';
+        new Setting(containerEl)
+            .setName('Reverse sync scope')
+            .setDesc('Completion only: tick/untick the checkbox, leaving the rest of the line alone. Everything: also apply content, due date, priority and labels, and append Todoist comments as sub-items.')
+            .addDropdown(dropdown =>
+                dropdown
+                    .addOption('status', 'Completion only (recommended)')
+                    .addOption('full', 'Everything (content, due date, priority, labels, notes)')
+                    .setValue(this.plugin.settings.todoistToObsidianScope)
+                    .onChange(async (value) => {
+                        await this.plugin.safeSettings?.update({ todoistToObsidianScope: value as 'status' | 'full' }, true);
+                        updateReverseSyncWarning();
+                        new Notice(`Reverse sync scope: ${value === 'full' ? 'everything' : 'completion only'}`);
+                    })
+            );
+
+        reverseSyncWarningEl = containerEl.createEl('div', { cls: 'setting-item-description' });
+        updateReverseSyncWarning();
 
         // ============================================
         // Device Management Section

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -582,8 +582,9 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
                         const missingResult = await cacheOperation.reclassifyMissingTaskIssues((doneCount, total) => {
                             progressNotice.setMessage(`Step 3/4: Checking task ${doneCount}/${total} against Todoist...`);
                         });
-                        if (missingResult.completed + missingResult.restored + missingResult.stillMissing + missingResult.unresolved > 0) {
+                        if (missingResult.migrated + missingResult.completed + missingResult.restored + missingResult.stillMissing + missingResult.unresolved > 0) {
                             const missingParts: string[] = [];
+                            if (missingResult.migrated > 0) missingParts.push(`🆔 Legacy IDs migrated: ${missingResult.migrated}`);
                             if (missingResult.completed > 0) missingParts.push(`✅ Completed in Todoist: ${missingResult.completed}`);
                             if (missingResult.restored > 0) missingParts.push(`🔄 Restored to sync: ${missingResult.restored}`);
                             if (missingResult.stillMissing > 0) missingParts.push(`🗑️ Confirmed deleted: ${missingResult.stillMissing}`);

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -501,7 +501,11 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
                         verifyNotice.hide();
                         const todoistCount = this.plugin.todoistSyncAPI?.getSyncData()?.items?.length ?? 0;
                         const vaultCount = Object.keys(this.plugin.settings.taskFileMapping).length;
-                        const status = result.success ? '✅ Healthy' : `⚠️ ${result.totalIssues} issues`;
+                        const settledCount = result.summary.taskNonActive;
+                        const settledSuffix = settledCount > 0 ? ` + ${settledCount} settled` : '';
+                        const status = result.success
+                            ? `✅ Healthy${settledSuffix}`
+                            : `⚠️ ${result.actionableIssues} issues${settledSuffix}`;
                         new Notice(
                             `Verify complete — ${status}\nTodoist: ${todoistCount} tasks | Vault: ${vaultCount} mapped tasks`,
                             8000
@@ -598,8 +602,8 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
                         });
                         await this.applyDatabaseIssuesToMapping(after);
                         progressNotice.hide();
-                        const fixedCount = Math.max(0, before.totalIssues - after.totalIssues);
-                        const remainingCount = after.totalIssues;
+                        const fixedCount = Math.max(0, before.actionableIssues - after.actionableIssues);
+                        const remainingCount = after.actionableIssues;
                         await this.plugin.safeSettings?.update({
                             lastDatabaseCheckTime: Date.now()
                         }, true);

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -518,7 +518,7 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
 
         new Setting(containerEl)
             .setName('Fix Database')
-            .setDesc('Run safe auto-repair for eligible issues only: (A) repair missing/stale mapping when Vault and Todoist already match, (B) mark completed-in-Vault and confirmed-missing-in-Todoist tasks as nonActive. Then re-check and report what still needs manual handling.')
+            .setDesc('Run safe auto-repair for eligible issues only: (A) repair missing/stale mapping when Vault and Todoist already match, (B) mark completed-in-Vault and confirmed-missing-in-Todoist tasks as nonActive, (C) re-check every task reported missing in Todoist by asking Todoist directly — tasks merely completed there are settled, and ones Todoist still has are put back into sync. Then re-check and report what still needs manual handling.')
             .addButton(button => button
                 .setButtonText('Run Safe Repair')
                 .onClick(async () => {
@@ -566,7 +566,7 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
                             return;
                         }
 
-                        progressNotice.setMessage(`Step 2/3: Found ${before.totalIssues} issues. Applying safe auto-repair...`);
+                        progressNotice.setMessage(`Step 2/4: Found ${before.totalIssues} issues. Applying safe auto-repair...`);
                         const autoRepairResult = await cacheOperation.applyMatchFirstAutoRepairs(before.issues as DatabaseCheckIssue[], true);
                         const autoRepairParts: string[] = [];
                         autoRepairParts.push(`🔧 Mapping repaired: ${autoRepairResult.mappingRepaired}`);
@@ -576,9 +576,24 @@ export class UltimateTodoistSyncSettingTab extends PluginSettingTab {
                         }
                         new Notice(autoRepairParts.join(' · '), 7000);
 
-                        progressNotice.setMessage('Step 3/3: Re-checking database...');
+                        // Ask Todoist directly about every task flagged as missing:
+                        // most of them were merely completed there.
+                        progressNotice.setMessage('Step 3/4: Re-checking tasks reported missing in Todoist...');
+                        const missingResult = await cacheOperation.reclassifyMissingTaskIssues((doneCount, total) => {
+                            progressNotice.setMessage(`Step 3/4: Checking task ${doneCount}/${total} against Todoist...`);
+                        });
+                        if (missingResult.completed + missingResult.restored + missingResult.stillMissing + missingResult.unresolved > 0) {
+                            const missingParts: string[] = [];
+                            if (missingResult.completed > 0) missingParts.push(`✅ Completed in Todoist: ${missingResult.completed}`);
+                            if (missingResult.restored > 0) missingParts.push(`🔄 Restored to sync: ${missingResult.restored}`);
+                            if (missingResult.stillMissing > 0) missingParts.push(`🗑️ Confirmed deleted: ${missingResult.stillMissing}`);
+                            if (missingResult.unresolved > 0) missingParts.push(`❓ Could not check: ${missingResult.unresolved}`);
+                            new Notice(missingParts.join(' · '), 8000);
+                        }
+
+                        progressNotice.setMessage('Step 4/4: Re-checking database...');
                         const after = await databaseChecker.checkDatabase((msg) => {
-                            progressNotice.setMessage(`Step 3/3: ${msg}`);
+                            progressNotice.setMessage(`Step 4/4: ${msg}`);
                         });
                         await this.applyDatabaseIssuesToMapping(after);
                         progressNotice.hide();

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -21,6 +21,10 @@ export interface TaskFileMappingEntry {
     syncEnabled?: boolean;
     updated_at?: string;
     note_count?: number;
+    /** Local epoch ms when this mapping was first created. Used as a grace window
+     *  before a task may be deleted, since a freshly written todoist_id can be
+     *  absent from the file text we read for a moment. */
+    createdAt?: number;
     issues?: Record<string, TaskIssueEntry>;
 }
 

--- a/src/storage/pathManager.ts
+++ b/src/storage/pathManager.ts
@@ -237,7 +237,7 @@ export class StoragePathManager {
         try {
             const file = this.app.vault.getAbstractFileByPath(path);
             if (file && 'stat' in file) {
-                return file.stat.mtime;
+                return (file as { stat: { mtime: number } }).stat.mtime;
             }
             return 0;
         } catch {

--- a/src/sync/scheduler.ts
+++ b/src/sync/scheduler.ts
@@ -4,6 +4,12 @@ export class SyncScheduler {
 	private plugin: UltimateTodoistSyncForObsidian;
 	private inProgress = false;
 
+	/**
+	 * Pause between the pull and push phases, so vault writes from the pull are
+	 * visible to the push. Only applied when the pull actually wrote something.
+	 */
+	private static readonly PULL_SETTLE_MS = 500;
+
 	constructor(plugin: UltimateTodoistSyncForObsidian) {
 		this.plugin = plugin;
 	}
@@ -32,12 +38,20 @@ export class SyncScheduler {
 				}
 			}
 
+			let pulledCount = 0;
 			await this.plugin.syncLockManager.run('todoistToObsidian', async () => {
-				await this.plugin.todoistToObsidian!.syncTodoistToObsidian();
+				pulledCount = await this.plugin.todoistToObsidian!.syncTodoistToObsidian();
 			});
 
 			await this.plugin.saveSettings();
-			await new Promise(resolve => setTimeout(resolve, 5000));
+
+			// Let vault writes from the pull settle before the push phase reads
+			// those files back. This used to be an unconditional 5s wait, which was
+			// the single largest cost of a sync pass even when the pull wrote
+			// nothing — and it is only needed when it did write.
+			if (pulledCount > 0) {
+				await new Promise(resolve => setTimeout(resolve, SyncScheduler.PULL_SETTLE_MS));
+			}
 
 			const filesToSync = this.getUniqueFiles();
 

--- a/src/sync/scheduler.ts
+++ b/src/sync/scheduler.ts
@@ -25,7 +25,7 @@ export class SyncScheduler {
 			if (Date.now() - lastFullSync > FULL_SYNC_INTERVAL) {
 				this.plugin.debugLog('Periodic full sync triggered');
 				try {
-					await this.plugin.todoistSyncAPI.initializeSync();
+					await this.plugin.todoistSyncAPI?.initializeSync();
 					await this.plugin.safeSettings?.update({ lastFullSyncTime: Date.now() }, true);
 				} catch (error) {
 					console.error('[Scheduler] Periodic full sync failed:', error);

--- a/src/sync/toObsidian.ts
+++ b/src/sync/toObsidian.ts
@@ -1,5 +1,5 @@
 import UltimateTodoistSyncForObsidian from "../../main";
-import { App, Notice, TFile } from 'obsidian';
+import { App, Notice } from 'obsidian';
 import { StoragePathManager } from '../storage/pathManager';
 
 export class TodoistToObsidianSync {
@@ -114,7 +114,7 @@ export class TodoistToObsidianSync {
             return;
         }
 
-        const fileContent = await this.app.vault.read(file as TFile);
+        const fileContent = await this.plugin.fileOperation!.readLiveFileContent(mapping.filePath);
         const lines = fileContent.split('\n');
 
         let taskLine = '';

--- a/src/sync/toObsidian.ts
+++ b/src/sync/toObsidian.ts
@@ -1,10 +1,17 @@
 import UltimateTodoistSyncForObsidian from "../../main";
 import { App, Notice } from 'obsidian';
 import { StoragePathManager } from '../storage/pathManager';
+import { resolveVanishedTask } from './vanishedTaskAction';
 
 export class TodoistToObsidianSync {
     app: App;
     plugin: UltimateTodoistSyncForObsidian;
+
+    /**
+     * A task created moments ago may not be in the sync data yet, so nothing is
+     * concluded about its absence inside this window.
+     */
+    private static readonly VANISHED_GRACE_MS = 60 * 1000;
 
     constructor(app: App, plugin: UltimateTodoistSyncForObsidian) {
         this.app = app;
@@ -56,8 +63,16 @@ export class TodoistToObsidianSync {
                     const task = itemMap.get(resolvedId) || itemMap.get(taskId);
 
                     if (!task || task.is_deleted) {
-                        if (this.plugin.settings.debugMode) {
-                            this.plugin.debugLog(`[Todoist→Obsidian] Task ${taskId} deleted or not found in sync data`);
+                        // Absent from the sync data does not mean deleted: completed
+                        // tasks drop out of /api/v1/sync entirely. Ask Todoist which
+                        // it was, so a task ticked off there gets ticked off here.
+                        try {
+                            const settled = await this.applyVanishedTask(taskId, mapping);
+                            if (!settled && this.plugin.settings.debugMode) {
+                                this.plugin.debugLog(`[Todoist→Obsidian] Task ${taskId} not in sync data, nothing concluded yet`);
+                            }
+                        } catch (error) {
+                            console.error(`[Todoist→Obsidian] Error resolving vanished task ${taskId}:`, error);
                         }
                         continue;
                     }
@@ -100,6 +115,71 @@ export class TodoistToObsidianSync {
             console.error('An error occurred while synchronizing:', err);
             this.plugin.logOperation?.log('SYNC_ERROR', `Sync failed: ${(err as Error).message}`, undefined, undefined, 'todoist→obsidian');
             new Notice(`Todoist sync failed: ${(err as Error).message}`);
+        }
+    }
+
+    /**
+     * Handle a mapped task that is no longer in the sync data.
+     *
+     * Returns true when the task reached a settled state (completed here too, or
+     * confirmed gone), false when nothing could be concluded and it should be
+     * looked at again on the next pass.
+     */
+    private async applyVanishedTask(
+        taskId: string,
+        mapping: { filePath: string; createdAt?: number }
+    ): Promise<boolean> {
+        const completionState = await this.plugin.todoistSyncAPI!.GetTaskCompletionState(taskId);
+        const vaultCompleted = await this.isTaskCompletedInVault(taskId, mapping.filePath);
+
+        const action = resolveVanishedTask({
+            completionState,
+            vaultCompleted,
+            mappingAgeMs: mapping.createdAt === undefined ? undefined : Date.now() - mapping.createdAt,
+            creationGraceMs: TodoistToObsidianSync.VANISHED_GRACE_MS,
+        });
+
+        switch (action) {
+            case 'complete-in-vault':
+                await this.plugin.fileOperation!.completeTaskInTheFile(taskId);
+                new Notice(`Task ${taskId} completed from Todoist`);
+                this.plugin.logOperation?.log('TODOIST_TASK_COMPLETED', `Task completed in Todoist: ${taskId}`, mapping.filePath, taskId, 'todoist→obsidian');
+                await this.settleCompletedTask(taskId, mapping.filePath);
+                return true;
+            case 'settle':
+                await this.settleCompletedTask(taskId, mapping.filePath);
+                return true;
+            case 'flag-missing':
+                // Genuinely deleted in Todoist while still open here. Leave the
+                // flagging to the push side and the database checker, which own the
+                // issue records and the user-facing resolution flow.
+                this.plugin.debugLog(`[Todoist→Obsidian] Task ${taskId} confirmed deleted in Todoist`);
+                return false;
+            case 'wait':
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Mark a task done on both sides as settled: nothing left to sync, and not a
+     * problem needing the user's attention.
+     */
+    private async settleCompletedTask(taskId: string, filePath: string): Promise<void> {
+        await this.plugin.cacheOperation!.setTaskFileMapping(taskId, filePath, 'nonActive', false);
+        this.plugin.debugLog(`[Todoist→Obsidian] Task ${taskId} settled as completed on both sides`);
+    }
+
+    private async isTaskCompletedInVault(taskId: string, filePath: string): Promise<boolean> {
+        try {
+            const content = await this.plugin.fileOperation!.readLiveFileContent(filePath);
+            const line = content.split('\n').find(
+                (candidate) => candidate.includes(taskId) && this.plugin.taskParser!.hasTodoistTag(candidate)
+            );
+            return line ? /\[(x|X)\]/.test(line) : false;
+        } catch (error) {
+            this.plugin.debugLog(`[Todoist→Obsidian] Could not read vault state for ${taskId}: ${(error as Error).message}`);
+            return false;
         }
     }
 

--- a/src/sync/toObsidian.ts
+++ b/src/sync/toObsidian.ts
@@ -18,7 +18,8 @@ export class TodoistToObsidianSync {
         this.plugin = plugin;
     }
 
-    async syncTodoistToObsidian(): Promise<void> {
+    /** @returns how many tasks were written to the vault. */
+    async syncTodoistToObsidian(): Promise<number> {
         try {
             this.plugin.logOperation?.log('SYNC_START', 'Starting sync from Todoist to Obsidian', undefined, undefined, 'todoist→obsidian');
 
@@ -27,7 +28,7 @@ export class TodoistToObsidianSync {
             const syncData = this.plugin.todoistSyncAPI!.getSyncData();
             if (!syncData?.items) {
                 this.plugin.debugLog('[Todoist→Obsidian] No sync data available');
-                return;
+                return 0;
             }
 
             const itemMap = new Map<string, any>();
@@ -111,10 +112,12 @@ export class TodoistToObsidianSync {
             if (syncedCount > 0) {
                 this.plugin.logOperation?.log('SYNC_COMPLETED', `Synced ${syncedCount} tasks from Todoist to Obsidian`);
             }
+            return syncedCount;
         } catch (err) {
             console.error('An error occurred while synchronizing:', err);
             this.plugin.logOperation?.log('SYNC_ERROR', `Sync failed: ${(err as Error).message}`, undefined, undefined, 'todoist→obsidian');
             new Notice(`Todoist sync failed: ${(err as Error).message}`);
+            return 0;
         }
     }
 

--- a/src/sync/toObsidian.ts
+++ b/src/sync/toObsidian.ts
@@ -235,12 +235,28 @@ export class TodoistToObsidianSync {
             this.plugin.logOperation?.log('TODOIST_TASK_REOPENED', `Task reopened in Todoist: ${taskId}`, mapping.filePath, taskId, 'todoist→obsidian');
         }
 
+        // The due date is applied in every scope, for the same reason as completion:
+        // its writer only swaps the date token (or inserts one before #todoist) and
+        // leaves the rest of the line alone. It also has to be pulled — a field that
+        // is not pulled but *is* pushed gets actively reverted in Todoist, because
+        // the next push sees the vault's older value as a local change.
+        const obsidianDueDate = this.plugin.taskParser!.getDueDateFromLineText(taskLine) || "";
+        const todoistDueDate = task.due?.date ? (this.plugin.taskParser!.ISOStringToLocalDateString(task.due.date) || "") : "";
+        if (obsidianDueDate !== todoistDueDate) {
+            await this.plugin.fileOperation!.syncTaskDueDateToFile(taskId, task.due?.date || "");
+            this.plugin.logOperation?.log('FILE_TASK_DUEDATE_SYNCED', `Synced due date: ${taskId}`, mapping.filePath, taskId, 'todoist→obsidian');
+        }
+
         // The remaining writers rebuild parts of the task line — content is a
         // substring replace, and the label and priority writers normalise tag
         // order and collapse runs of spaces — so they can reformat or overwrite
         // text the user edited in Obsidian. Only apply them in the full scope.
+        //
+        // Note the consequence of leaving them out: for those fields Obsidian stays
+        // authoritative, so a change made to them in Todoist is overwritten on the
+        // next push. That is the trade the limited scope makes.
         if (this.plugin.settings.todoistToObsidianScope !== 'full') {
-            this.plugin.debugLog(`[syncSingleTaskToObsidian] Task ${taskId}: status-only scope, leaving line text untouched`);
+            this.plugin.debugLog(`[syncSingleTaskToObsidian] Task ${taskId}: limited scope, leaving line text untouched`);
             return;
         }
 
@@ -248,13 +264,6 @@ export class TodoistToObsidianSync {
         if (obsidianContent && task.content && obsidianContent !== task.content) {
             await this.plugin.fileOperation!.syncTaskContentToFile(taskId, task.content);
             this.plugin.logOperation?.log('FILE_TASK_CONTENT_SYNCED', `Synced content: ${taskId}`, mapping.filePath, taskId, 'todoist→obsidian');
-        }
-
-        const obsidianDueDate = this.plugin.taskParser!.getDueDateFromLineText(taskLine) || "";
-        const todoistDueDate = task.due?.date ? (this.plugin.taskParser!.ISOStringToLocalDateString(task.due.date) || "") : "";
-        if (obsidianDueDate !== todoistDueDate) {
-            await this.plugin.fileOperation!.syncTaskDueDateToFile(taskId, task.due?.date || "");
-            this.plugin.logOperation?.log('FILE_TASK_DUEDATE_SYNCED', `Synced due date: ${taskId}`, mapping.filePath, taskId, 'todoist→obsidian');
         }
 
         const prioritySynced = await this.plugin.fileOperation!.syncTaskPriorityToFile(taskId, task.priority || 1);

--- a/src/sync/toObsidian.ts
+++ b/src/sync/toObsidian.ts
@@ -82,7 +82,13 @@ export class TodoistToObsidianSync {
                     }
                 }
 
-                await this.syncNotesToObsidian(taskFileMapping, noteMap, idMapping);
+                // Notes insert new lines into the note, so they are part of the
+                // full scope. note_count is deliberately left untouched in
+                // status-only scope: switching to full later then appends the
+                // backlog rather than silently dropping it.
+                if (this.plugin.settings.todoistToObsidianScope === 'full') {
+                    await this.syncNotesToObsidian(taskFileMapping, noteMap, idMapping);
+                }
             } finally {
                 this.plugin.isSyncingFromTodoist = false;
             }
@@ -134,6 +140,8 @@ export class TodoistToObsidianSync {
         const obsidianIsChecked = /\[(x|X)\]/.test(taskLine);
         const todoistIsChecked = task.checked || false;
 
+        // Completion status is the one field that rewrites nothing but the
+        // checkbox, so it is applied in every scope.
         if (todoistIsChecked && !obsidianIsChecked) {
             await this.plugin.fileOperation!.completeTaskInTheFile(taskId);
             new Notice(`Task ${taskId} completed from Todoist`);
@@ -142,6 +150,15 @@ export class TodoistToObsidianSync {
             await this.plugin.fileOperation!.uncompleteTaskInTheFile(taskId);
             new Notice(`Task ${taskId} reopened from Todoist`);
             this.plugin.logOperation?.log('TODOIST_TASK_REOPENED', `Task reopened in Todoist: ${taskId}`, mapping.filePath, taskId, 'todoist→obsidian');
+        }
+
+        // The remaining writers rebuild parts of the task line — content is a
+        // substring replace, and the label and priority writers normalise tag
+        // order and collapse runs of spaces — so they can reformat or overwrite
+        // text the user edited in Obsidian. Only apply them in the full scope.
+        if (this.plugin.settings.todoistToObsidianScope !== 'full') {
+            this.plugin.debugLog(`[syncSingleTaskToObsidian] Task ${taskId}: status-only scope, leaving line text untouched`);
+            return;
         }
 
         const obsidianContent = this.plugin.taskParser!.getTaskContentFromLineText(taskLine);

--- a/src/sync/toObsidian.ts
+++ b/src/sync/toObsidian.ts
@@ -1,5 +1,5 @@
 import UltimateTodoistSyncForObsidian from "../../main";
-import { App, Notice } from 'obsidian';
+import { App, Notice, TFile } from 'obsidian';
 import { StoragePathManager } from '../storage/pathManager';
 
 export class TodoistToObsidianSync {
@@ -15,9 +15,9 @@ export class TodoistToObsidianSync {
         try {
             this.plugin.logOperation?.log('SYNC_START', 'Starting sync from Todoist to Obsidian', undefined, undefined, 'todoist→obsidian');
 
-            await this.plugin.todoistSyncAPI.incrementalSync();
+            await this.plugin.todoistSyncAPI!.incrementalSync();
 
-            const syncData = this.plugin.todoistSyncAPI.getSyncData();
+            const syncData = this.plugin.todoistSyncAPI!.getSyncData();
             if (!syncData?.items) {
                 this.plugin.debugLog('[Todoist→Obsidian] No sync data available');
                 return;
@@ -40,14 +40,20 @@ export class TodoistToObsidianSync {
             const taskFileMapping = this.plugin.settings.taskFileMapping || {};
             let syncedCount = 0;
 
+            // Resolve legacy numeric IDs → new string IDs so we can look up
+            // tasks in the Sync API response (which uses new IDs).
+            const cacheTaskIds = Object.keys(taskFileMapping);
+            const idMapping = await this.resolveTaskIds(cacheTaskIds);
+
             // Set flag: file writes below are from Todoist pull, not user edits
             this.plugin.isSyncingFromTodoist = true;
             try {
-                for (const taskId of Object.keys(taskFileMapping)) {
+                for (const taskId of cacheTaskIds) {
                     const mapping = taskFileMapping[taskId];
                     if (mapping.syncEnabled === false) continue;
 
-                    const task = itemMap.get(taskId);
+                    const resolvedId = idMapping[taskId] || taskId;
+                    const task = itemMap.get(resolvedId) || itemMap.get(taskId);
 
                     if (!task || task.is_deleted) {
                         if (this.plugin.settings.debugMode) {
@@ -67,7 +73,7 @@ export class TodoistToObsidianSync {
                     try {
                         await this.syncSingleTaskToObsidian(taskId, task);
                         syncedCount++;
-                        await this.plugin.cacheOperation.updateTaskMappingSyncMeta(taskId, {
+                        await this.plugin.cacheOperation!.updateTaskMappingSyncMeta(taskId, {
                             updated_at: task.updated_at,
                             note_count: task.note_count || 0
                         });
@@ -76,7 +82,7 @@ export class TodoistToObsidianSync {
                     }
                 }
 
-                await this.syncNotesToObsidian(taskFileMapping, noteMap);
+                await this.syncNotesToObsidian(taskFileMapping, noteMap, idMapping);
             } finally {
                 this.plugin.isSyncingFromTodoist = false;
             }
@@ -92,7 +98,7 @@ export class TodoistToObsidianSync {
     }
 
     private async syncSingleTaskToObsidian(taskId: string, task: any): Promise<void> {
-        const mapping = this.plugin.cacheOperation.getTaskFileMapping(taskId);
+        const mapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId);
         if (!mapping) {
             console.warn(`[syncSingleTaskToObsidian] No mapping found for task ${taskId}`);
             this.plugin.debugLog(`[syncSingleTaskToObsidian] No mapping found for task ${taskId}`);
@@ -108,12 +114,12 @@ export class TodoistToObsidianSync {
             return;
         }
 
-        const fileContent = await this.app.vault.read(file);
+        const fileContent = await this.app.vault.read(file as TFile);
         const lines = fileContent.split('\n');
 
         let taskLine = '';
         for (const line of lines) {
-            if (line.includes(taskId) && this.plugin.taskParser.hasTodoistTag(line)) {
+            if (line.includes(taskId) && this.plugin.taskParser!.hasTodoistTag(line)) {
                 taskLine = line;
                 break;
             }
@@ -129,34 +135,34 @@ export class TodoistToObsidianSync {
         const todoistIsChecked = task.checked || false;
 
         if (todoistIsChecked && !obsidianIsChecked) {
-            await this.plugin.fileOperation.completeTaskInTheFile(taskId);
+            await this.plugin.fileOperation!.completeTaskInTheFile(taskId);
             new Notice(`Task ${taskId} completed from Todoist`);
             this.plugin.logOperation?.log('TODOIST_TASK_COMPLETED', `Task completed in Todoist: ${taskId}`, mapping.filePath, taskId, 'todoist→obsidian');
         } else if (!todoistIsChecked && obsidianIsChecked) {
-            await this.plugin.fileOperation.uncompleteTaskInTheFile(taskId);
+            await this.plugin.fileOperation!.uncompleteTaskInTheFile(taskId);
             new Notice(`Task ${taskId} reopened from Todoist`);
             this.plugin.logOperation?.log('TODOIST_TASK_REOPENED', `Task reopened in Todoist: ${taskId}`, mapping.filePath, taskId, 'todoist→obsidian');
         }
 
-        const obsidianContent = this.plugin.taskParser.getTaskContentFromLineText(taskLine);
+        const obsidianContent = this.plugin.taskParser!.getTaskContentFromLineText(taskLine);
         if (obsidianContent && task.content && obsidianContent !== task.content) {
-            await this.plugin.fileOperation.syncTaskContentToFile(taskId, task.content);
+            await this.plugin.fileOperation!.syncTaskContentToFile(taskId, task.content);
             this.plugin.logOperation?.log('FILE_TASK_CONTENT_SYNCED', `Synced content: ${taskId}`, mapping.filePath, taskId, 'todoist→obsidian');
         }
 
-        const obsidianDueDate = this.plugin.taskParser.getDueDateFromLineText(taskLine) || "";
-        const todoistDueDate = task.due?.date ? (this.plugin.taskParser.ISOStringToLocalDateString(task.due.date) || "") : "";
+        const obsidianDueDate = this.plugin.taskParser!.getDueDateFromLineText(taskLine) || "";
+        const todoistDueDate = task.due?.date ? (this.plugin.taskParser!.ISOStringToLocalDateString(task.due.date) || "") : "";
         if (obsidianDueDate !== todoistDueDate) {
-            await this.plugin.fileOperation.syncTaskDueDateToFile(taskId, task.due?.date || "");
+            await this.plugin.fileOperation!.syncTaskDueDateToFile(taskId, task.due?.date || "");
             this.plugin.logOperation?.log('FILE_TASK_DUEDATE_SYNCED', `Synced due date: ${taskId}`, mapping.filePath, taskId, 'todoist→obsidian');
         }
 
-        const prioritySynced = await this.plugin.fileOperation.syncTaskPriorityToFile(taskId, task.priority || 1);
+        const prioritySynced = await this.plugin.fileOperation!.syncTaskPriorityToFile(taskId, task.priority || 1);
         if (prioritySynced) {
             this.plugin.logOperation?.log('FILE_TASK_PRIORITY_SYNCED', `Synced priority: ${taskId}`, mapping.filePath, taskId, 'todoist→obsidian');
         }
 
-        const labelsSynced = await this.plugin.fileOperation.syncTaskLabelsToFile(taskId, task.labels || []);
+        const labelsSynced = await this.plugin.fileOperation!.syncTaskLabelsToFile(taskId, task.labels || []);
         if (labelsSynced) {
             this.plugin.logOperation?.log('FILE_TASK_LABELS_SYNCED', `Synced labels: ${taskId}`, mapping.filePath, taskId, 'todoist→obsidian');
         }
@@ -164,9 +170,22 @@ export class TodoistToObsidianSync {
 
     private async syncNotesToObsidian(
         taskFileMapping: Record<string, { note_count?: number; syncEnabled?: boolean }>,
-        noteMap: Map<string, any[]>
+        noteMap: Map<string, any[]>,
+        idMapping: Record<string, string>
     ): Promise<void> {
-        for (const [taskId, notes] of noteMap.entries()) {
+        // Build reverse map: newId → cacheId so we can look up noteMap entries
+        // (keyed by new IDs from syncData) against taskFileMapping (keyed by
+        // cache IDs which may be legacy numeric IDs).
+        const reverseIdMap = new Map<string, string>();
+        for (const [cacheId, resolvedId] of Object.entries(idMapping)) {
+            if (resolvedId !== cacheId) {
+                reverseIdMap.set(resolvedId, cacheId);
+            }
+        }
+
+        for (const [noteTaskId, notes] of noteMap.entries()) {
+            // noteTaskId is from syncData (new ID). Find corresponding cache ID.
+            const taskId = reverseIdMap.get(noteTaskId) || noteTaskId;
             const mapping = taskFileMapping[taskId];
             if (!mapping) continue;
             if (mapping.syncEnabled === false) continue;
@@ -181,23 +200,44 @@ export class TodoistToObsidianSync {
             const newNotes = sortedNotes.slice(storedNoteCount);
             for (const note of newNotes) {
                 try {
-                    const dateStr = this.plugin.taskParser.ISOStringToLocalDatetimeString(note.posted_at || note.added_at || '');
-                    await this.plugin.fileOperation.syncTaskNoteToFile(taskId, note.content || '', dateStr);
+                    const dateStr = this.plugin.taskParser!.ISOStringToLocalDatetimeString(note.posted_at || note.added_at || '');
+                    await this.plugin.fileOperation!.syncTaskNoteToFile(taskId, note.content || '', dateStr ?? '');
                     new Notice(`Note synced to task ${taskId}`);
                 } catch (error) {
                     console.error(`[Todoist→Obsidian] Error syncing note for task ${taskId}:`, error);
                 }
             }
 
-            await this.plugin.cacheOperation.updateTaskMappingSyncMeta(taskId, {
+            await this.plugin.cacheOperation!.updateTaskMappingSyncMeta(taskId, {
                 note_count: notes.length
             });
         }
     }
 
+    /**
+     * Resolve legacy numeric task IDs to new string IDs via the REST API
+     * ID mapping endpoint. Returns a map of oldId → newId for any IDs that
+     * were translated; non-legacy IDs are excluded.
+     */
+    private async resolveTaskIds(taskIds: string[]): Promise<Record<string, string>> {
+        const restApi = this.plugin.todoistRestAPI;
+        if (!restApi) return {};
+        try {
+            return await restApi.resolveIds('tasks', taskIds);
+        } catch (err) {
+            console.warn('[Todoist→Obsidian] Failed to resolve legacy task IDs, proceeding with original IDs:', err);
+            return {};
+        }
+    }
+
     async backupTodoistAllResources(): Promise<void> {
         try {
-            const resources = await this.plugin.todoistSyncAPI.getAllResources(true);
+            const todoistSyncAPI = this.plugin.todoistSyncAPI;
+            if (!todoistSyncAPI) {
+                throw new Error('Todoist sync API is not initialized');
+            }
+
+            const resources = await todoistSyncAPI.getAllResources(true);
 
             const now: Date = new Date();
             const timeString = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}-${String(now.getHours()).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}${String(now.getSeconds()).padStart(2, '0')}`;

--- a/src/sync/toTodoist.ts
+++ b/src/sync/toTodoist.ts
@@ -5,6 +5,14 @@ export class ObsidianToTodoistSync {
     app: App;
     plugin: UltimateTodoistSyncForObsidian;
 
+    /**
+     * A task created moments ago may legitimately be absent from the file text we
+     * read — the write-back is still in flight, or the editor buffer holding it has
+     * not been flushed yet. Deleting a Todoist task is irreversible, so never do it
+     * inside this window; a genuinely deleted line is picked up on the next pass.
+     */
+    private static readonly DELETE_GRACE_MS = 60 * 1000;
+
     constructor(app: App, plugin: UltimateTodoistSyncForObsidian) {
         this.app = app;
         this.plugin = plugin;
@@ -68,11 +76,18 @@ export class ObsidianToTodoistSync {
 
         const currentFileValueWithOutFrontMatter = (currentFileValue ?? '').replace(/^---[\s\S]*?---\n/, '');
 
-        const tasksToDelete = taskIds.filter(
-            (taskId: string) =>
-                !currentFileValueWithOutFrontMatter.includes(taskId) &&
-                cacheOperation.isTaskSyncEnabled(taskId)
-        );
+        const now = Date.now();
+        const tasksToDelete = taskIds.filter((taskId: string) => {
+            if (currentFileValueWithOutFrontMatter.includes(taskId)) return false;
+            if (!cacheOperation.isTaskSyncEnabled(taskId)) return false;
+
+            const createdAt = cacheOperation.getTaskFileMapping(taskId)?.createdAt;
+            if (createdAt && now - createdAt < ObsidianToTodoistSync.DELETE_GRACE_MS) {
+                this.plugin.debugLog(`[deletedTaskCheck] Task ${taskId} created ${now - createdAt}ms ago, within delete grace window — skipping`);
+                return false;
+            }
+            return true;
+        });
 
         let deletedCount = 0;
         for (const taskId of tasksToDelete) {

--- a/src/sync/toTodoist.ts
+++ b/src/sync/toTodoist.ts
@@ -154,8 +154,22 @@ export class ObsidianToTodoistSync {
 
                 await cacheOperation.setTaskFileMapping(todoist_id, filepath || '');
 
+                // Close before snapshotting updated_at below — closing bumps the
+                // Todoist revision, and a snapshot taken before it would leave the
+                // mapping permanently one revision behind, which reads as a conflict
+                // on the next edit of this line.
+                if (currentTask.isCompleted === true) {
+                    await todoistSyncAPI.CloseTask(newTask.id);
+                    // taskFileMapping already set above
+                    this.plugin.logOperation?.log('OBSIDIAN_TASK_COMPLETED', `Completed task in Obsidian: ${newTask.content}`, filepath, todoist_id, 'obsidian→todoist');
+                    this.plugin.logOperation?.log('TODOIST_TASK_COMPLETED', `Completed task in Todoist: ${newTask.content}`, filepath, todoist_id, 'obsidian→todoist');
+                }
+
                 // Immediately sync so syncData contains the new task before any
-                // subsequent lineModifiedTaskCheck fires on the same line.
+                // subsequent lineModifiedTaskCheck fires on the same line. The
+                // revision must come from syncData, never from the SDK's return
+                // value: the mapping stores the sync endpoint's updated_at string,
+                // while the SDK hands back a Date, and the two do not compare equal.
                 try {
                     await todoistSyncAPI.incrementalSync();
                     const updatedTask = await todoistSyncAPI.GetTaskById(todoist_id);
@@ -164,13 +178,6 @@ export class ObsidianToTodoistSync {
                     }
                 } catch (syncErr) {
                     console.error('[lineContentNewTaskCheck] Post-create incremental sync failed:', syncErr);
-                }
-
-                if (currentTask.isCompleted === true) {
-                    await todoistSyncAPI.CloseTask(newTask.id);
-                    // taskFileMapping already set above
-                    this.plugin.logOperation?.log('OBSIDIAN_TASK_COMPLETED', `Completed task in Obsidian: ${newTask.content}`, filepath, todoist_id, 'obsidian→todoist');
-                    this.plugin.logOperation?.log('TODOIST_TASK_COMPLETED', `Completed task in Todoist: ${newTask.content}`, filepath, todoist_id, 'obsidian→todoist');
                 }
 
                 const text_with_out_link = `${processedLine} %%[todoist_id:: ${todoist_id}]%%`;
@@ -260,6 +267,13 @@ export class ObsidianToTodoistSync {
 
             await cacheOperation.setTaskFileMapping(todoist_id, filepath || '');
 
+            // Close before snapshotting updated_at below \u2014 see lineContentNewTaskCheck.
+            if (currentTask.isCompleted === true) {
+                await todoistSyncAPI.CloseTask(newTask.id);
+                this.plugin.logOperation?.log('OBSIDIAN_TASK_COMPLETED', `Completed task in Obsidian: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
+                this.plugin.logOperation?.log('TODOIST_TASK_COMPLETED', `Completed task in Todoist: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
+            }
+
             // Immediately sync so syncData contains the new task
             try {
                 await todoistSyncAPI.incrementalSync();
@@ -269,12 +283,6 @@ export class ObsidianToTodoistSync {
                 }
             } catch (syncErr) {
                 console.error('[lastLineNewTaskCheck] Post-create incremental sync failed:', syncErr);
-            }
-
-            if (currentTask.isCompleted === true) {
-                await todoistSyncAPI.CloseTask(newTask.id);
-                this.plugin.logOperation?.log('OBSIDIAN_TASK_COMPLETED', `Completed task in Obsidian: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
-                this.plugin.logOperation?.log('TODOIST_TASK_COMPLETED', `Completed task in Todoist: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
             }
 
             // Write tag + id + link back to the file

--- a/src/sync/toTodoist.ts
+++ b/src/sync/toTodoist.ts
@@ -13,6 +13,13 @@ export class ObsidianToTodoistSync {
      */
     private static readonly DELETE_GRACE_MS = 60 * 1000;
 
+    /**
+     * A task's own creation triggers follow-up writes of our own (close,
+     * description). A revision that moved this recently is far more likely to be
+     * one of those than a competing edit by a person.
+     */
+    private static readonly CONFLICT_GRACE_MS = 60 * 1000;
+
     constructor(app: App, plugin: UltimateTodoistSyncForObsidian) {
         this.app = app;
         this.plugin = plugin;
@@ -46,6 +53,61 @@ export class ObsidianToTodoistSync {
         }
 
         return file;
+    }
+
+    /**
+     * Decide whether a Todoist revision that moved since we last recorded it should
+     * stop an Obsidian-side push.
+     *
+     * A moved revision on its own says very little: only that the task changed at
+     * some point since we last looked. It does not say a person changed it, nor
+     * that the change collides with what Obsidian wants to write. Treating every
+     * mismatch as a conflict flagged tasks on a bare cursor move — lineNumberCheck
+     * fires on every arrow key, and fullTextModifiedTaskCheck walks every task line
+     * in the file — and left them disabled forever once any single revision refresh
+     * had been missed.
+     *
+     * `announce` marks outcomes the user chose via conflictResolutionStrategy, so
+     * the quiet automatic cases do not spam notices.
+     */
+    private decideConflict(
+        taskId: string,
+        taskMapping: { updated_at?: string; createdAt?: number },
+        savedTask: { updated_at?: string },
+        hasLocalChanges: boolean
+    ): { action: 'no-conflict' | 'push' | 'pull' | 'block'; announce: boolean } {
+        const quiet = (action: 'no-conflict' | 'push' | 'pull' | 'block') => ({ action, announce: false });
+
+        // No recorded revision means no basis for comparison.
+        if (!taskMapping.updated_at || !savedTask.updated_at) return quiet('no-conflict');
+        if (savedTask.updated_at === taskMapping.updated_at) return quiet('no-conflict');
+
+        // An unchanged line has nothing to overwrite, so there is nothing to
+        // conflict with. Leave the recorded revision stale on purpose: that is
+        // exactly what makes the pull direction pick the change up.
+        if (!hasLocalChanges) {
+            this.plugin.debugLog(`[decideConflict] Task ${taskId}: Todoist moved but Obsidian has no changes to push`);
+            return quiet('no-conflict');
+        }
+
+        const createdAt = taskMapping.createdAt;
+        if (createdAt && Date.now() - createdAt < ObsidianToTodoistSync.CONFLICT_GRACE_MS) {
+            this.plugin.debugLog(`[decideConflict] Task ${taskId}: revision moved inside its creation window, treating as our own write`);
+            return quiet('push');
+        }
+
+        // With the pull direction off the user has declared Obsidian the source of
+        // truth. Blocking on a Todoist change that will never be applied would
+        // disable the task permanently.
+        if (!this.plugin.settings.todoistToObsidianEnabled) {
+            this.plugin.debugLog(`[decideConflict] Task ${taskId}: Todoist→Obsidian disabled, pushing Obsidian's version`);
+            return quiet('push');
+        }
+
+        const strategy = this.plugin.settings.conflictResolutionStrategy;
+        if (strategy === 'todoist-wins') return { action: 'pull', announce: true };
+        if (strategy === 'obsidian-wins') return { action: 'push', announce: true };
+        return { action: 'block', announce: true };
     }
 
     async deletedTaskCheck(file_path: string): Promise<number> {
@@ -476,37 +538,41 @@ export class ObsidianToTodoistSync {
                 return;
             }
 
-            // Conflict detection: if Todoist was updated since our last sync
-            if (taskMapping.updated_at && savedTask.updated_at && savedTask.updated_at !== taskMapping.updated_at) {
-                const strategy = this.plugin.settings.conflictResolutionStrategy;
-                console.warn(`[lineModifiedTaskCheck] Conflict on task ${lineTask_todoist_id}: strategy=${strategy}`);
-                this.plugin.logOperation?.log('CONFLICT_DETECTED', `Conflict on task ${lineTask_todoist_id} (strategy: ${strategy})`, filepath, lineTask_todoist_id);
-
-                if (strategy === 'todoist-wins') {
-                    // Let toObsidian pull overwrite Obsidian on next sync — just update cached updated_at
-                    await cacheOperation.updateTaskMappingSyncMeta(lineTask_todoist_id, { updated_at: undefined });
-                    new Notice(`Conflict on task ${lineTask_todoist_id}: Todoist wins — Obsidian will be updated on next sync.`);
-                    return;
-                } else if (strategy === 'obsidian-wins') {
-                    // Force-update Todoist with Obsidian content — fall through to normal update logic below
-                    new Notice(`Conflict on task ${lineTask_todoist_id}: Obsidian wins — pushing to Todoist.`);
-                    // Reset cached updated_at so toObsidian won't overwrite back
-                    await cacheOperation.updateTaskMappingSyncMeta(lineTask_todoist_id, { updated_at: savedTask.updated_at });
-                    // fall through
-                } else {
-                    // manual: disable sync until user resolves
-                    await cacheOperation.setTaskFileMapping(lineTask_todoist_id, taskMapping.filePath, 'conflicted', false);
-                    new Notice(`Task ${lineTask_todoist_id} has a conflict: modified in both Obsidian and Todoist. Sync disabled until resolved.`);
-                    return;
-                }
-            }
-
             const lineTaskContent = lineTask.content;
             const contentModified = !taskParser.taskContentCompare(lineTask, savedTask);
             const tagsModified = !taskParser.taskTagCompare(lineTask, savedTask);
             const statusModified = !taskParser.taskStatusCompare(lineTask, savedTask);
             const dueDateModified = !taskParser.compareTaskDueDate(lineTask, savedTask);
             const priorityModified = !taskParser.taskPriorityCompare(lineTask, savedTask);
+            const hasLocalChanges = contentModified || tagsModified || statusModified || dueDateModified || priorityModified;
+
+            // Conflict detection: Todoist moved on since we last recorded it *and*
+            // Obsidian has something it wants to overwrite.
+            const conflict = this.decideConflict(lineTask_todoist_id, taskMapping, savedTask, hasLocalChanges);
+            if (conflict.action !== 'no-conflict' && conflict.announce) {
+                const strategy = this.plugin.settings.conflictResolutionStrategy;
+                console.warn(`[lineModifiedTaskCheck] Conflict on task ${lineTask_todoist_id}: strategy=${strategy}`);
+                this.plugin.logOperation?.log('CONFLICT_DETECTED', `Conflict on task ${lineTask_todoist_id} (strategy: ${strategy})`, filepath, lineTask_todoist_id);
+            }
+
+            if (conflict.action === 'pull') {
+                // Leaving the recorded revision stale is what makes the pull re-apply
+                // Todoist's version, so there is nothing to write here.
+                new Notice(`Conflict on task ${lineTask_todoist_id}: Todoist wins — Obsidian will be updated on next sync.`);
+                return;
+            }
+            if (conflict.action === 'block') {
+                await cacheOperation.setTaskFileMapping(lineTask_todoist_id, taskMapping.filePath, 'conflicted', false);
+                new Notice(`Task ${lineTask_todoist_id} has a conflict: modified in both Obsidian and Todoist. Sync disabled until resolved.`);
+                return;
+            }
+            if (conflict.action === 'push') {
+                // Record what we observed so the pull direction will not undo the push.
+                await cacheOperation.updateTaskMappingSyncMeta(lineTask_todoist_id, { updated_at: savedTask.updated_at });
+                if (conflict.announce) {
+                    new Notice(`Conflict on task ${lineTask_todoist_id}: Obsidian wins — pushing to Todoist.`);
+                }
+            }
 
             try {
                 let contentChanged = false;
@@ -679,19 +745,24 @@ export class ObsidianToTodoistSync {
                 return;
             }
 
-            if (taskMapping?.updated_at && savedTask.updated_at && savedTask.updated_at !== taskMapping.updated_at) {
-                const strategy = this.plugin.settings.conflictResolutionStrategy;
-                this.plugin.logOperation?.log('CONFLICT_DETECTED', `Conflict on closeTask ${taskId} (strategy: ${strategy})`, undefined, taskId);
-                if (strategy === 'todoist-wins') {
-                    await cacheOperation.updateTaskMappingSyncMeta(taskId, { updated_at: undefined });
+            if (taskMapping) {
+                // Todoist already being in the requested state means the checkbox
+                // click has nothing to push, so nothing can collide with it.
+                const conflict = this.decideConflict(taskId, taskMapping, savedTask, !savedTask.checked);
+                if (conflict.announce) {
+                    const strategy = this.plugin.settings.conflictResolutionStrategy;
+                    this.plugin.logOperation?.log('CONFLICT_DETECTED', `Conflict on closeTask ${taskId} (strategy: ${strategy})`, undefined, taskId);
+                }
+                if (conflict.action === 'pull') {
                     new Notice(`Conflict on task ${taskId}: Todoist wins — Obsidian will be updated on next sync.`);
                     return;
-                } else if (strategy === 'manual') {
+                }
+                if (conflict.action === 'block') {
                     await cacheOperation.setTaskFileMapping(taskId, taskMapping.filePath, 'conflicted', false);
                     new Notice(`Task ${taskId} has a conflict. Sync disabled until resolved.`);
                     return;
                 }
-                // obsidian-wins: fall through and close
+                // no-conflict / push: close it
             }
 
             await todoistSyncAPI.CloseTask(taskId);
@@ -745,19 +816,24 @@ export class ObsidianToTodoistSync {
                 return;
             }
 
-            if (taskMapping?.updated_at && savedTask.updated_at && savedTask.updated_at !== taskMapping.updated_at) {
-                const strategy = this.plugin.settings.conflictResolutionStrategy;
-                this.plugin.logOperation?.log('CONFLICT_DETECTED', `Conflict on repoenTask ${taskId} (strategy: ${strategy})`, undefined, taskId);
-                if (strategy === 'todoist-wins') {
-                    await cacheOperation.updateTaskMappingSyncMeta(taskId, { updated_at: undefined });
+            if (taskMapping) {
+                // Todoist already being in the requested state means the checkbox
+                // click has nothing to push, so nothing can collide with it.
+                const conflict = this.decideConflict(taskId, taskMapping, savedTask, !!savedTask.checked);
+                if (conflict.announce) {
+                    const strategy = this.plugin.settings.conflictResolutionStrategy;
+                    this.plugin.logOperation?.log('CONFLICT_DETECTED', `Conflict on repoenTask ${taskId} (strategy: ${strategy})`, undefined, taskId);
+                }
+                if (conflict.action === 'pull') {
                     new Notice(`Conflict on task ${taskId}: Todoist wins — Obsidian will be updated on next sync.`);
                     return;
-                } else if (strategy === 'manual') {
+                }
+                if (conflict.action === 'block') {
                     await cacheOperation.setTaskFileMapping(taskId, taskMapping.filePath, 'conflicted', false);
                     new Notice(`Task ${taskId} has a conflict. Sync disabled until resolved.`);
                     return;
                 }
-                // obsidian-wins: fall through and reopen
+                // no-conflict / push: reopen it
             }
 
             await todoistSyncAPI.OpenTask(taskId);

--- a/src/sync/toTodoist.ts
+++ b/src/sync/toTodoist.ts
@@ -1,5 +1,6 @@
 import UltimateTodoistSyncForObsidian from "../../main";
 import { App, Editor, MarkdownView, Notice, TFile } from 'obsidian';
+import { resolveVanishedTask } from './vanishedTaskAction';
 
 export class ObsidianToTodoistSync {
     app: App;
@@ -506,25 +507,46 @@ export class ObsidianToTodoistSync {
 
             if (!cacheOperation.isTaskSyncEnabled(lineTask_todoist_id)) {
                 this.plugin.debugLog(`[lineModifiedTaskCheck] Sync disabled for task ${lineTask_todoist_id}, skipping modification`);
-                this.plugin.logOperation?.log('SYNC_DISABLED_SKIP', `User edit ignored: sync disabled for task ${lineTask_todoist_id}`, filepath, lineTask_todoist_id);
+                // Only worth an operation-log entry while the task still needs the
+                // user's attention. A settled ('nonActive') task is skipped on every
+                // scheduler pass forever, and logging that buries the whole log —
+                // 4696 of 4698 entries in one real vault were exactly this.
+                if (cacheOperation.getTaskFileMapping(lineTask_todoist_id)?.status !== 'nonActive') {
+                    this.plugin.logOperation?.log('SYNC_DISABLED_SKIP', `User edit ignored: sync disabled for task ${lineTask_todoist_id}`, filepath, lineTask_todoist_id);
+                }
                 return;
             }
 
             const savedTask = await todoistSyncAPI.GetTaskById(lineTask_todoist_id);
 
-            // Handle deleted task: task exists in cache but not in Todoist
+            // Not in the sync data. That does not mean deleted: a task completed in
+            // Todoist drops out of /api/v1/sync entirely rather than coming back
+            // with checked=true, so ask Todoist which it was before concluding.
             if (!savedTask) {
-                // If the task was just created (mapping exists but syncData not yet updated),
-                // skip silently rather than marking as issue. The incremental sync running
-                // in the background will populate syncData shortly.
-                const mappingAge = taskMapping.updated_at
-                    ? Date.now() - new Date(taskMapping.updated_at).getTime()
-                    : 0;
-                if (mappingAge < 30000) {
-                    this.plugin.debugLog(`[lineModifiedTaskCheck] Task ${lineTask_todoist_id} not in syncData yet (just created), skipping`);
+                const action = resolveVanishedTask({
+                    completionState: await todoistSyncAPI.GetTaskCompletionState(lineTask_todoist_id),
+                    vaultCompleted: lineTask.isCompleted === true,
+                    mappingAgeMs: taskMapping.createdAt === undefined
+                        ? undefined
+                        : Date.now() - taskMapping.createdAt,
+                    creationGraceMs: ObsidianToTodoistSync.CONFLICT_GRACE_MS,
+                });
+
+                if (action === 'complete-in-vault' || action === 'settle') {
+                    // Done in Todoist. Settle it rather than reporting a problem —
+                    // the pull direction ticks the checkbox when it is enabled.
+                    await cacheOperation.setTaskFileMapping(lineTask_todoist_id, taskMapping.filePath, 'nonActive', false);
+                    this.plugin.debugLog(`[lineModifiedTaskCheck] Task ${lineTask_todoist_id} is completed in Todoist, marking nonActive`);
+                    this.plugin.logOperation?.log('TODOIST_TASK_COMPLETED', `Task completed in Todoist: ${lineTask_todoist_id}`, filepath, lineTask_todoist_id, 'todoist→obsidian');
                     return;
                 }
-                console.warn(`[lineModifiedTaskCheck] Task ${lineTask_todoist_id} not found in Todoist (deleted?), marking as issue`);
+
+                if (action !== 'flag-missing') {
+                    this.plugin.debugLog(`[lineModifiedTaskCheck] Task ${lineTask_todoist_id} not in syncData and nothing concluded (${action}), skipping`);
+                    return;
+                }
+
+                console.warn(`[lineModifiedTaskCheck] Task ${lineTask_todoist_id} confirmed deleted in Todoist, marking as issue`);
                 await cacheOperation.setTaskFileMapping(lineTask_todoist_id, taskMapping.filePath, 'issue', false);
 				await cacheOperation.upsertTaskIssue(lineTask_todoist_id, 'todoist_task_missing', {
                     state: 'open',
@@ -733,6 +755,27 @@ export class ObsidianToTodoistSync {
             const savedTask = await todoistSyncAPI.GetTaskById(taskId);
 
             if (!savedTask) {
+                // Absent from the sync data may mean completed rather than deleted.
+                const action = resolveVanishedTask({
+                    completionState: await todoistSyncAPI.GetTaskCompletionState(taskId),
+                    vaultCompleted: true,
+                    mappingAgeMs: taskMapping?.createdAt === undefined
+                        ? undefined
+                        : Date.now() - taskMapping.createdAt,
+                    creationGraceMs: ObsidianToTodoistSync.CONFLICT_GRACE_MS,
+                });
+
+                if (action === 'complete-in-vault' || action === 'settle') {
+                    await cacheOperation.setTaskFileMapping(taskId, taskMapping?.filePath || '', 'nonActive', false);
+                    this.plugin.debugLog(`[closeTask] Task ${taskId} is already completed in Todoist, marking nonActive`);
+                    return;
+                }
+
+                if (action !== 'flag-missing') {
+                    this.plugin.debugLog(`[closeTask] Task ${taskId} not in syncData and nothing concluded (${action}), skipping`);
+                    return;
+                }
+
                 await cacheOperation.setTaskFileMapping(taskId, taskMapping?.filePath || '', 'issue', false);
 				await cacheOperation.upsertTaskIssue(taskId, 'todoist_task_missing', {
                     state: 'open',
@@ -804,6 +847,27 @@ export class ObsidianToTodoistSync {
             const savedTask = await todoistSyncAPI.GetTaskById(taskId);
 
             if (!savedTask) {
+                // Absent from the sync data may mean completed rather than deleted.
+                const action = resolveVanishedTask({
+                    completionState: await todoistSyncAPI.GetTaskCompletionState(taskId),
+                    vaultCompleted: false,
+                    mappingAgeMs: taskMapping?.createdAt === undefined
+                        ? undefined
+                        : Date.now() - taskMapping.createdAt,
+                    creationGraceMs: ObsidianToTodoistSync.CONFLICT_GRACE_MS,
+                });
+
+                if (action === 'complete-in-vault' || action === 'settle') {
+                    await cacheOperation.setTaskFileMapping(taskId, taskMapping?.filePath || '', 'nonActive', false);
+                    this.plugin.debugLog(`[repoenTask] Task ${taskId} is already completed in Todoist, marking nonActive`);
+                    return;
+                }
+
+                if (action !== 'flag-missing') {
+                    this.plugin.debugLog(`[repoenTask] Task ${taskId} not in syncData and nothing concluded (${action}), skipping`);
+                    return;
+                }
+
                 await cacheOperation.setTaskFileMapping(taskId, taskMapping?.filePath || '', 'issue', false);
 				await cacheOperation.upsertTaskIssue(taskId, 'todoist_task_missing', {
                     state: 'open',

--- a/src/sync/toTodoist.ts
+++ b/src/sync/toTodoist.ts
@@ -1,5 +1,5 @@
 import UltimateTodoistSyncForObsidian from "../../main";
-import { App, Editor, MarkdownView, Notice } from 'obsidian';
+import { App, Editor, MarkdownView, Notice, TFile } from 'obsidian';
 
 export class ObsidianToTodoistSync {
     app: App;
@@ -10,48 +10,81 @@ export class ObsidianToTodoistSync {
         this.plugin = plugin;
     }
 
+    private requireServices() {
+        const {
+            taskParser,
+            cacheOperation,
+            todoistSyncAPI,
+            fileOperation,
+            backupOperation,
+        } = this.plugin;
+
+        if (!taskParser || !cacheOperation || !todoistSyncAPI || !fileOperation) {
+            throw new Error('Todoist sync services are not initialized');
+        }
+
+        return {
+            taskParser,
+            cacheOperation,
+            todoistSyncAPI,
+            fileOperation,
+            backupOperation,
+        };
+    }
+
+    private requireTFile(file: unknown, context: string): TFile {
+        if (!(file instanceof TFile)) {
+            throw new Error(`${context}: target file not found`);
+        }
+
+        return file;
+    }
+
     async deletedTaskCheck(file_path: string): Promise<number> {
         if (!this.plugin.isPrimaryDevice()) {
             this.plugin.debugLog('[toTodoist] Push blocked: not primary device');
             return 0;
         }
+        const { cacheOperation, todoistSyncAPI } = this.requireServices();
         let file;
-        let currentFileValue;
+        let currentFileValue: string;
         let view;
-        let filepath;
+        let filepath: string;
         if (file_path) {
             file = this.app.vault.getAbstractFileByPath(file_path);
+            file = this.requireTFile(file, 'deletedTaskCheck');
             filepath = file_path;
             currentFileValue = await this.app.vault.read(file);
         } else {
             view = this.app.workspace.getActiveViewOfType(MarkdownView);
             file = this.app.workspace.getActiveFile();
-            filepath = file?.path;
-            currentFileValue = view?.data;
+            file = this.requireTFile(file, 'deletedTaskCheck');
+            filepath = file.path;
+            currentFileValue = view?.data ?? '';
         }
-        const taskIds = this.plugin.cacheOperation.getTasksInFile(filepath);
+        const taskIds = cacheOperation.getTasksInFile(filepath);
         if (taskIds.length === 0) {
             this.plugin.debugLog('No tasks in this file');
             return 0;
         }
 
-        const currentFileValueWithOutFrontMatter = currentFileValue.replace(/^---[\s\S]*?---\n/, '');
+        const currentFileValueWithOutFrontMatter = (currentFileValue ?? '').replace(/^---[\s\S]*?---\n/, '');
 
         const tasksToDelete = taskIds.filter(
             (taskId: string) =>
                 !currentFileValueWithOutFrontMatter.includes(taskId) &&
-                this.plugin.cacheOperation.isTaskSyncEnabled(taskId)
+                cacheOperation.isTaskSyncEnabled(taskId)
         );
 
         let deletedCount = 0;
         for (const taskId of tasksToDelete) {
             try {
-                const api = this.plugin.todoistSyncAPI.initializeAPI();
+                const api = todoistSyncAPI.initializeAPI();
                 const response = await api.deleteTask(taskId);
                 if (response) {
                     new Notice(`task ${taskId} is deleted`);
                     this.plugin.logOperation?.log('OBSIDIAN_TASK_DELETED', `Deleted task: ${taskId}`, undefined, taskId);
-                    await this.plugin.cacheOperation.deleteTaskFileMapping(taskId);
+                    await cacheOperation.deleteTaskFileMapping(taskId);
                     deletedCount++;
                 }
             } catch (error) {
@@ -66,7 +99,7 @@ export class ObsidianToTodoistSync {
 				console.warn('[deletedTaskCheck] saveSettings skipped or failed');
 			}
 			try {
-				await this.plugin.todoistSyncAPI.incrementalSync();
+                await todoistSyncAPI.incrementalSync();
 			} catch (syncErr) {
 				console.error('[deletedTaskCheck] Post-push incremental sync failed:', syncErr);
             }
@@ -80,24 +113,25 @@ export class ObsidianToTodoistSync {
             this.plugin.debugLog('[toTodoist] Push blocked: not primary device');
             return;
         }
+        const { taskParser, cacheOperation, todoistSyncAPI } = this.requireServices();
         const filepath = view.file?.path;
         const fileContent = view?.data;
         const cursor = editor.getCursor();
         const line = cursor.line;
         const linetxt = editor.getLine(line);
 
-        const hasId = this.plugin.taskParser.hasTodoistId(linetxt);
-        const hasTag = this.plugin.taskParser.hasTodoistTag(linetxt);
+        const hasId = taskParser.hasTodoistId(linetxt);
+        const hasTag = taskParser.hasTodoistTag(linetxt);
         const isNewTask = !hasId && hasTag;
 
         if (isNewTask) {
-            const processedLine = hasTag ? linetxt : this.plugin.taskParser.addTodoistTag(linetxt);
+            const processedLine = hasTag ? linetxt : taskParser.addTodoistTag(linetxt);
             this.plugin.debugLog('this is a new task');
             this.plugin.debugLog(processedLine);
-            const currentTask = await this.plugin.taskParser.convertTextToTodoistTaskObject(processedLine, filepath, line, fileContent);
+            const currentTask = await taskParser.convertTextToTodoistTaskObject(processedLine, filepath, line, fileContent);
 
             try {
-                const newTask = await this.plugin.todoistSyncAPI.AddTask(currentTask);
+                const newTask = await todoistSyncAPI.AddTask(currentTask);
                 const { id: todoist_id } = newTask;
                 newTask.path = filepath;
                 new Notice(`new task ${newTask.content} id is ${newTask.id}`);
@@ -105,22 +139,22 @@ export class ObsidianToTodoistSync {
                 this.plugin.logOperation?.log('OBSIDIAN_TASK_CREATED', `Created task in Obsidian: ${newTask.content}`, filepath, todoist_id, 'obsidian→todoist');
                 this.plugin.logOperation?.log('TODOIST_TASK_CREATED', `Created task in Todoist: ${newTask.content}`, filepath, todoist_id, 'obsidian→todoist');
 
-				await this.plugin.cacheOperation.setTaskFileMapping(todoist_id, filepath || '');
+                await cacheOperation.setTaskFileMapping(todoist_id, filepath || '');
 
                 // Immediately sync so syncData contains the new task before any
                 // subsequent lineModifiedTaskCheck fires on the same line.
                 try {
-                    await this.plugin.todoistSyncAPI.incrementalSync();
-                    const updatedTask = await this.plugin.todoistSyncAPI.GetTaskById(todoist_id);
+                    await todoistSyncAPI.incrementalSync();
+                    const updatedTask = await todoistSyncAPI.GetTaskById(todoist_id);
                     if (updatedTask?.updated_at) {
-                        await this.plugin.cacheOperation.updateTaskMappingSyncMeta(todoist_id, { updated_at: updatedTask.updated_at });
+                        await cacheOperation.updateTaskMappingSyncMeta(todoist_id, { updated_at: updatedTask.updated_at });
                     }
                 } catch (syncErr) {
                     console.error('[lineContentNewTaskCheck] Post-create incremental sync failed:', syncErr);
                 }
 
                 if (currentTask.isCompleted === true) {
-                    await this.plugin.todoistSyncAPI.CloseTask(newTask.id);
+                    await todoistSyncAPI.CloseTask(newTask.id);
                     // taskFileMapping already set above
                     this.plugin.logOperation?.log('OBSIDIAN_TASK_COMPLETED', `Completed task in Obsidian: ${newTask.content}`, filepath, todoist_id, 'obsidian→todoist');
                     this.plugin.logOperation?.log('TODOIST_TASK_COMPLETED', `Completed task in Todoist: ${newTask.content}`, filepath, todoist_id, 'obsidian→todoist');
@@ -128,7 +162,7 @@ export class ObsidianToTodoistSync {
 
                 const text_with_out_link = `${processedLine} %%[todoist_id:: ${todoist_id}]%%`;
                 const link = this.plugin.settings.useAppURI ? `[link](todoist://task?id=${newTask.id})` : `[link](https://app.todoist.com/app/task/${newTask.id})`;
-                const text = this.plugin.taskParser.addTodoistLink(text_with_out_link, link);
+                const text = taskParser.addTodoistLink(text_with_out_link, link);
                 const from = { line: cursor.line, ch: 0 };
                 const to = { line: cursor.line, ch: linetxt.length };
                 try {
@@ -137,12 +171,12 @@ export class ObsidianToTodoistSync {
                     // replaceRange failed — roll back Todoist task to avoid duplicate on next trigger
                     console.error('[lineContentNewTaskCheck] replaceRange failed, rolling back Todoist task:', replaceError);
                     try {
-                        const api = this.plugin.todoistSyncAPI.initializeAPI();
+                        const api = todoistSyncAPI.initializeAPI();
                         await api.deleteTask(todoist_id);
                     } catch (deleteError) {
                         console.error('[lineContentNewTaskCheck] Rollback failed:', deleteError);
                     }
-                    await this.plugin.cacheOperation.deleteTaskFileMapping(todoist_id);
+                    await cacheOperation.deleteTaskFileMapping(todoist_id);
                     new Notice(`Failed to write task ID to file. Todoist task rolled back. Please try again.`);
                     return;
                 }
@@ -175,25 +209,26 @@ export class ObsidianToTodoistSync {
             this.plugin.debugLog('[lastLineNewTaskCheck] Push blocked: not primary device');
             return;
         }
+        const { taskParser, cacheOperation, todoistSyncAPI } = this.requireServices();
         if (!this.plugin.settings.enableFullVaultSync) return;
 
-        const isTask = this.plugin.taskParser.isMarkdownTask(lineText);
+        const isTask = taskParser.isMarkdownTask(lineText);
         if (!isTask) return;
 
-        const contentNotEmpty = this.plugin.taskParser.getTaskContentFromLineText(lineText) !== '';
+        const contentNotEmpty = taskParser.getTaskContentFromLineText(lineText) !== '';
         if (!contentNotEmpty) return;
 
-        const hasId = this.plugin.taskParser.hasTodoistId(lineText);
+        const hasId = taskParser.hasTodoistId(lineText);
         if (hasId) return;
 
-        const hasTag = this.plugin.taskParser.hasTodoistTag(lineText);
+        const hasTag = taskParser.hasTodoistTag(lineText);
         if (hasTag) return; // Already has #todoist — lineContentNewTaskCheck will handle it
 
         // Add #todoist tag
-        const processedLine = this.plugin.taskParser.addTodoistTag(lineText);
+        const processedLine = taskParser.addTodoistTag(lineText);
         this.plugin.debugLog('[lastLineNewTaskCheck] New task detected on line leave:', processedLine);
 
-        const currentTask = await this.plugin.taskParser.convertTextToTodoistTaskObject(processedLine, filepath, lineNumber, fileContent);
+        const currentTask = await taskParser.convertTextToTodoistTaskObject(processedLine, filepath, lineNumber, fileContent);
         if (typeof currentTask === 'undefined') {
             console.warn(`[lastLineNewTaskCheck] Task parser returned undefined for line: ${processedLine}`);
             this.plugin.debugLog(`[lastLineNewTaskCheck] Task parser returned undefined for line ${lineNumber} in ${filepath}`);
@@ -202,7 +237,7 @@ export class ObsidianToTodoistSync {
         }
 
         try {
-            const newTask = await this.plugin.todoistSyncAPI.AddTask(currentTask);
+            const newTask = await todoistSyncAPI.AddTask(currentTask);
             const { id: todoist_id } = newTask;
             newTask.path = filepath;
             new Notice(`new task ${newTask.content} id is ${newTask.id}`);
@@ -210,21 +245,21 @@ export class ObsidianToTodoistSync {
             this.plugin.logOperation?.log('OBSIDIAN_TASK_CREATED', `Created task in Obsidian: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
             this.plugin.logOperation?.log('TODOIST_TASK_CREATED', `Created task in Todoist: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
 
-            await this.plugin.cacheOperation.setTaskFileMapping(todoist_id, filepath || '');
+            await cacheOperation.setTaskFileMapping(todoist_id, filepath || '');
 
             // Immediately sync so syncData contains the new task
             try {
-                await this.plugin.todoistSyncAPI.incrementalSync();
-                const updatedTask = await this.plugin.todoistSyncAPI.GetTaskById(todoist_id);
+                await todoistSyncAPI.incrementalSync();
+                const updatedTask = await todoistSyncAPI.GetTaskById(todoist_id);
                 if (updatedTask?.updated_at) {
-                    await this.plugin.cacheOperation.updateTaskMappingSyncMeta(todoist_id, { updated_at: updatedTask.updated_at });
+                    await cacheOperation.updateTaskMappingSyncMeta(todoist_id, { updated_at: updatedTask.updated_at });
                 }
             } catch (syncErr) {
                 console.error('[lastLineNewTaskCheck] Post-create incremental sync failed:', syncErr);
             }
 
             if (currentTask.isCompleted === true) {
-                await this.plugin.todoistSyncAPI.CloseTask(newTask.id);
+                await todoistSyncAPI.CloseTask(newTask.id);
                 this.plugin.logOperation?.log('OBSIDIAN_TASK_COMPLETED', `Completed task in Obsidian: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
                 this.plugin.logOperation?.log('TODOIST_TASK_COMPLETED', `Completed task in Todoist: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
             }
@@ -232,19 +267,16 @@ export class ObsidianToTodoistSync {
             // Write tag + id + link back to the file
             const text_with_out_link = `${processedLine} %%[todoist_id:: ${todoist_id}]%%`;
             const link = this.plugin.settings.useAppURI ? `[link](todoist://task?id=${newTask.id})` : `[link](https://app.todoist.com/app/task/${newTask.id})`;
-            const text = this.plugin.taskParser.addTodoistLink(text_with_out_link, link);
+            const text = taskParser.addTodoistLink(text_with_out_link, link);
 
             // Use vault.read + vault.modify since cursor is no longer on this line
             const file = this.app.vault.getAbstractFileByPath(filepath);
-            if (!file) {
-                console.error(`[lastLineNewTaskCheck] File not found: ${filepath}`);
-                return;
-            }
-            const currentContent = await this.app.vault.read(file);
+            const taskFile = this.requireTFile(file, 'lastLineNewTaskCheck');
+            const currentContent = await this.app.vault.read(taskFile);
             const lines = currentContent.split('\n');
             if (lineNumber < lines.length) {
                 lines[lineNumber] = text;
-                await this.app.vault.modify(file, lines.join('\n'));
+                await this.app.vault.modify(taskFile, lines.join('\n'));
             }
 
             const saved = await this.plugin.saveSettings();
@@ -263,34 +295,37 @@ export class ObsidianToTodoistSync {
             this.plugin.debugLog('[toTodoist] Push blocked: not primary device');
             return;
         }
+        const { taskParser, cacheOperation, todoistSyncAPI, backupOperation, fileOperation } = this.requireServices();
         let file;
-        let currentFileValue;
+        let currentFileValue: string;
         let view;
-        let filepath;
+        let filepath: string;
         if (file_path) {
             file = this.app.vault.getAbstractFileByPath(file_path);
+            file = this.requireTFile(file, 'fullTextNewTaskCheck');
             filepath = file_path;
             currentFileValue = await this.app.vault.read(file);
         } else {
             view = this.app.workspace.getActiveViewOfType(MarkdownView);
             file = this.app.workspace.getActiveFile();
-            filepath = file?.path;
-            currentFileValue = view?.data;
+            file = this.requireTFile(file, 'fullTextNewTaskCheck');
+            filepath = file.path;
+            currentFileValue = view?.data ?? '';
         }
         // Prevent per-task vault.modify from triggering modify event storm
         this.plugin.isProcessingModify = true;
         try {
         if (this.plugin.settings.enableFullVaultSync) {
-            await this.plugin.fileOperation.addTodoistTagToFile(filepath);
+            await fileOperation.addTodoistTagToFile(filepath);
             currentFileValue = await this.app.vault.read(file);
         }
 
             let lines = currentFileValue.split('\n');
         for (let i = 0; i < lines.length; i++) {
                 const line = lines[i];
-                if (!this.plugin.taskParser.hasTodoistId(line) && this.plugin.taskParser.hasTodoistTag(line)) {
+                if (!taskParser.hasTodoistId(line) && taskParser.hasTodoistTag(line)) {
                     this.plugin.debugLog(filepath);
-                    const currentTask = await this.plugin.taskParser.convertTextToTodoistTaskObject(line, filepath, i, lines.join('\n'));
+                    const currentTask = await taskParser.convertTextToTodoistTaskObject(line, filepath, i, lines.join('\n'));
                     if (typeof currentTask === 'undefined') {
                         console.warn(`[fullTextNewTaskCheck] Task parser returned undefined for line ${i} in ${filepath}`);
                         this.plugin.debugLog(`[fullTextNewTaskCheck] Task parser returned undefined for line ${i} in ${filepath}`);
@@ -300,7 +335,7 @@ export class ObsidianToTodoistSync {
                 this.plugin.debugLog(currentTask);
                     let todoist_id: string | undefined;
                     try {
-                        const newTask = await this.plugin.todoistSyncAPI.AddTask(currentTask);
+                        const newTask = await todoistSyncAPI.AddTask(currentTask);
                         todoist_id = newTask.id;
                         newTask.path = filepath;
                         this.plugin.debugLog(newTask);
@@ -308,29 +343,29 @@ export class ObsidianToTodoistSync {
                         this.plugin.logOperation?.log('OBSIDIAN_TASK_CREATED', `Created task in Obsidian: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
                         this.plugin.logOperation?.log('TODOIST_TASK_CREATED', `Created task in Todoist: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
 
-					await this.plugin.cacheOperation.setTaskFileMapping(todoist_id, filepath || '');
+					await cacheOperation.setTaskFileMapping(todoist_id!, filepath || '');
                     if (currentTask.isCompleted === true) {
-                            await this.plugin.todoistSyncAPI.CloseTask(newTask.id);
+                            await todoistSyncAPI.CloseTask(newTask.id);
                             this.plugin.logOperation?.log('OBSIDIAN_TASK_COMPLETED', `Completed task in Obsidian: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
                             this.plugin.logOperation?.log('TODOIST_TASK_COMPLETED', `Completed task in Todoist: ${newTask.content}`, filepath, todoist_id, 'obsidian\u2192todoist');
                         }
                     const text_with_out_link = `${line} %%[todoist_id:: ${todoist_id}]%%`;
                         const link = this.plugin.settings.useAppURI ? `[link](todoist://task?id=${newTask.id})` : `[link](https://app.todoist.com/app/task/${newTask.id})`;
-                        const text = this.plugin.taskParser.addTodoistLink(text_with_out_link, link);
+                        const text = taskParser.addTodoistLink(text_with_out_link, link);
                     lines[i] = text;
                         // Atomic: write file immediately after each task
                         const newContent = lines.join('\n');
-                        await this.plugin.backupOperation?.backupFile(filepath);
+                        await backupOperation?.backupFile(filepath);
                         await this.app.vault.modify(file, newContent);
 					const saved = await this.plugin.saveSettings();
 					if (!saved) {
 						console.warn('[fullTextNewTaskCheck] saveSettings skipped or failed');
 					}
                         try {
-                            await this.plugin.todoistSyncAPI.incrementalSync();
-                            const updatedTask = await this.plugin.todoistSyncAPI.GetTaskById(todoist_id);
+                            await todoistSyncAPI.incrementalSync();
+                            const updatedTask = await todoistSyncAPI.GetTaskById(todoist_id!);
                             if (updatedTask?.updated_at) {
-                                await this.plugin.cacheOperation.updateTaskMappingSyncMeta(todoist_id, { updated_at: updatedTask.updated_at });
+                                await cacheOperation.updateTaskMappingSyncMeta(todoist_id!, { updated_at: updatedTask.updated_at });
                             }
                         } catch (syncErr) {
                             console.error('[fullTextNewTaskCheck] Post-push incremental sync failed:', syncErr);
@@ -345,11 +380,11 @@ export class ObsidianToTodoistSync {
                         // Rollback: delete Todoist task + clean mapping if we got an id
                         if (todoist_id) {
                             try {
-                                await this.plugin.todoistSyncAPI.deleteTask(todoist_id);
+                                await todoistSyncAPI.deleteTask(todoist_id);
                             } catch (deleteError) {
                                 console.error('[fullTextNewTaskCheck] Rollback deleteTask failed:', deleteError);
                             }
-                            await this.plugin.cacheOperation.deleteTaskFileMapping(todoist_id);
+                            await cacheOperation.deleteTaskFileMapping(todoist_id);
                         }
                         continue;
                     }
@@ -365,25 +400,29 @@ export class ObsidianToTodoistSync {
             this.plugin.debugLog('[toTodoist] Push blocked: not primary device');
             return;
         }
-        if (this.plugin.taskParser.hasTodoistId(lineText) && this.plugin.taskParser.hasTodoistTag(lineText)) {
-            const lineTask = await this.plugin.taskParser.convertTextToTodoistTaskObject(lineText, filepath, lineNumber, fileContent);
-            const lineTask_todoist_id = (lineTask.todoist_id).toString();
+        const { taskParser, cacheOperation, todoistSyncAPI } = this.requireServices();
+        if (taskParser.hasTodoistId(lineText) && taskParser.hasTodoistTag(lineText)) {
+            const lineTask = await taskParser.convertTextToTodoistTaskObject(lineText, filepath, lineNumber, fileContent);
+            if (!lineTask || !lineTask.todoist_id) {
+                return;
+            }
+            const lineTask_todoist_id = lineTask.todoist_id.toString();
 
-            const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(lineTask_todoist_id);
+            const taskMapping = cacheOperation.getTaskFileMapping(lineTask_todoist_id);
             if (!taskMapping) {
                 this.plugin.debugLog(`Local cache has no task ${lineTask.todoist_id}`);
-                const url = this.plugin.taskParser.getObsidianUrlFromFilepath(filepath);
+                const url = taskParser.getObsidianUrlFromFilepath(filepath);
                 this.plugin.debugLog(url);
                 return;
             }
 
-            if (!this.plugin.cacheOperation.isTaskSyncEnabled(lineTask_todoist_id)) {
+            if (!cacheOperation.isTaskSyncEnabled(lineTask_todoist_id)) {
                 this.plugin.debugLog(`[lineModifiedTaskCheck] Sync disabled for task ${lineTask_todoist_id}, skipping modification`);
                 this.plugin.logOperation?.log('SYNC_DISABLED_SKIP', `User edit ignored: sync disabled for task ${lineTask_todoist_id}`, filepath, lineTask_todoist_id);
                 return;
             }
 
-            const savedTask = await this.plugin.todoistSyncAPI.GetTaskById(lineTask_todoist_id);
+            const savedTask = await todoistSyncAPI.GetTaskById(lineTask_todoist_id);
 
             // Handle deleted task: task exists in cache but not in Todoist
             if (!savedTask) {
@@ -398,8 +437,8 @@ export class ObsidianToTodoistSync {
                     return;
                 }
                 console.warn(`[lineModifiedTaskCheck] Task ${lineTask_todoist_id} not found in Todoist (deleted?), marking as issue`);
-                await this.plugin.cacheOperation.setTaskFileMapping(lineTask_todoist_id, taskMapping.filePath, 'issue', false);
-				await this.plugin.cacheOperation.upsertTaskIssue(lineTask_todoist_id, 'todoist_task_missing', {
+                await cacheOperation.setTaskFileMapping(lineTask_todoist_id, taskMapping.filePath, 'issue', false);
+				await cacheOperation.upsertTaskIssue(lineTask_todoist_id, 'todoist_task_missing', {
                     state: 'open',
                     severity: 'high',
                     source: 'runtime',
@@ -419,29 +458,29 @@ export class ObsidianToTodoistSync {
 
                 if (strategy === 'todoist-wins') {
                     // Let toObsidian pull overwrite Obsidian on next sync — just update cached updated_at
-                    await this.plugin.cacheOperation.updateTaskMappingSyncMeta(lineTask_todoist_id, { updated_at: undefined });
+                    await cacheOperation.updateTaskMappingSyncMeta(lineTask_todoist_id, { updated_at: undefined });
                     new Notice(`Conflict on task ${lineTask_todoist_id}: Todoist wins — Obsidian will be updated on next sync.`);
                     return;
                 } else if (strategy === 'obsidian-wins') {
                     // Force-update Todoist with Obsidian content — fall through to normal update logic below
                     new Notice(`Conflict on task ${lineTask_todoist_id}: Obsidian wins — pushing to Todoist.`);
                     // Reset cached updated_at so toObsidian won't overwrite back
-                    await this.plugin.cacheOperation.updateTaskMappingSyncMeta(lineTask_todoist_id, { updated_at: savedTask.updated_at });
+                    await cacheOperation.updateTaskMappingSyncMeta(lineTask_todoist_id, { updated_at: savedTask.updated_at });
                     // fall through
                 } else {
                     // manual: disable sync until user resolves
-                    await this.plugin.cacheOperation.setTaskFileMapping(lineTask_todoist_id, taskMapping.filePath, 'conflicted', false);
+                    await cacheOperation.setTaskFileMapping(lineTask_todoist_id, taskMapping.filePath, 'conflicted', false);
                     new Notice(`Task ${lineTask_todoist_id} has a conflict: modified in both Obsidian and Todoist. Sync disabled until resolved.`);
                     return;
                 }
             }
 
             const lineTaskContent = lineTask.content;
-            const contentModified = !this.plugin.taskParser.taskContentCompare(lineTask, savedTask);
-            const tagsModified = !this.plugin.taskParser.taskTagCompare(lineTask, savedTask);
-            const statusModified = !this.plugin.taskParser.taskStatusCompare(lineTask, savedTask);
-            const dueDateModified = !this.plugin.taskParser.compareTaskDueDate(lineTask, savedTask);
-            const priorityModified = !this.plugin.taskParser.taskPriorityCompare(lineTask, savedTask);
+            const contentModified = !taskParser.taskContentCompare(lineTask, savedTask);
+            const tagsModified = !taskParser.taskTagCompare(lineTask, savedTask);
+            const statusModified = !taskParser.taskStatusCompare(lineTask, savedTask);
+            const dueDateModified = !taskParser.compareTaskDueDate(lineTask, savedTask);
+            const priorityModified = !taskParser.taskPriorityCompare(lineTask, savedTask);
 
             try {
                 let contentChanged = false;
@@ -480,7 +519,7 @@ export class ObsidianToTodoistSync {
                 }
 
                 if (contentChanged || tagsChanged || dueDateChanged || priorityChanged) {
-                    const updatedTask = await this.plugin.todoistSyncAPI.UpdateTask(lineTask.todoist_id.toString(), updatedContent);
+                    const updatedTask = await todoistSyncAPI.UpdateTask(lineTask_todoist_id, updatedContent);
                     // taskFileMapping already set, no need to update
                     this.plugin.logOperation?.log('OBSIDIAN_TASK_MODIFIED', `Updated task: ${updatedTask.content}`, filepath, lineTask_todoist_id, 'obsidian→todoist');
                     this.plugin.logOperation?.log('TODOIST_TASK_UPDATED', `Updated task in Todoist: ${updatedTask.content}`, filepath, lineTask_todoist_id, 'obsidian→todoist');
@@ -490,13 +529,13 @@ export class ObsidianToTodoistSync {
                     this.plugin.debugLog(`Status modified for task ${lineTask_todoist_id}`);
                     if (lineTask.isCompleted === true) {
                         this.plugin.debugLog(`task completed`);
-                        await this.plugin.todoistSyncAPI.CloseTask(lineTask.todoist_id.toString());
+                        await todoistSyncAPI.CloseTask(lineTask_todoist_id);
                         // taskFileMapping already set, no need to update
                         this.plugin.logOperation?.log('OBSIDIAN_TASK_COMPLETED', `Completed task: ${lineTask.content}`, filepath, lineTask_todoist_id, 'obsidian→todoist');
                         this.plugin.logOperation?.log('TODOIST_TASK_COMPLETED', `Completed task in Todoist: ${lineTask.content}`, filepath, lineTask_todoist_id, 'obsidian→todoist');
                     } else {
                         this.plugin.debugLog(`task uncompleted`);
-                        await this.plugin.todoistSyncAPI.OpenTask(lineTask.todoist_id.toString());
+                        await todoistSyncAPI.OpenTask(lineTask_todoist_id);
                         // taskFileMapping already set, no need to update
                         this.plugin.logOperation?.log('OBSIDIAN_TASK_REOPENED', `Reopened task: ${lineTask.content}`, filepath, lineTask_todoist_id);
                         this.plugin.logOperation?.log('TODOIST_TASK_REOPENED', `Reopened task in Todoist: ${lineTask.content}`, filepath, lineTask_todoist_id, 'obsidian→todoist');
@@ -512,10 +551,10 @@ export class ObsidianToTodoistSync {
 						console.warn('[lineModifiedTaskCheck] saveSettings skipped or failed');
 					}
                     try {
-                        await this.plugin.todoistSyncAPI.incrementalSync();
-                        const refreshedTask = await this.plugin.todoistSyncAPI.GetTaskById(lineTask_todoist_id);
+                        await todoistSyncAPI.incrementalSync();
+                        const refreshedTask = await todoistSyncAPI.GetTaskById(lineTask_todoist_id);
                         if (refreshedTask?.updated_at) {
-                            await this.plugin.cacheOperation.updateTaskMappingSyncMeta(lineTask_todoist_id, { updated_at: refreshedTask.updated_at });
+                            await cacheOperation.updateTaskMappingSyncMeta(lineTask_todoist_id, { updated_at: refreshedTask.updated_at });
                         }
                     } catch (syncErr) {
                         console.error('[lineModifiedTaskCheck] Post-push incremental sync failed:', syncErr);
@@ -549,6 +588,7 @@ export class ObsidianToTodoistSync {
     }
 
     async fullTextModifiedTaskCheck(file_path: string): Promise<void> {
+        const { taskParser } = this.requireServices();
         let file;
         let currentFileValue;
         let view;
@@ -557,21 +597,23 @@ export class ObsidianToTodoistSync {
         try {
             if (file_path) {
                 file = this.app.vault.getAbstractFileByPath(file_path);
+                file = this.requireTFile(file, 'fullTextModifiedTaskCheck');
                 filepath = file_path;
                 currentFileValue = await this.app.vault.read(file);
             } else {
                 view = this.app.workspace.getActiveViewOfType(MarkdownView);
                 file = this.app.workspace.getActiveFile();
+                file = this.requireTFile(file, 'fullTextModifiedTaskCheck');
                 filepath = file?.path;
                 currentFileValue = view?.data;
             }
 
-            const content = currentFileValue;
+            const content = currentFileValue ?? '';
             const lines = content.split('\n');
 
             for (let i = 0; i < lines.length; i++) {
                 const line = lines[i];
-                if (this.plugin.taskParser.hasTodoistId(line) && this.plugin.taskParser.hasTodoistTag(line)) {
+                if (taskParser.hasTodoistId(line) && taskParser.hasTodoistTag(line)) {
                     try {
                         await this.lineModifiedTaskCheck(filepath, line, i, content);
                     } catch (error) {
@@ -590,18 +632,19 @@ export class ObsidianToTodoistSync {
             this.plugin.debugLog('[toTodoist] Push blocked: not primary device');
             return;
         }
-        if (!this.plugin.cacheOperation?.isTaskSyncEnabled(taskId)) {
+        const { cacheOperation, todoistSyncAPI, fileOperation } = this.requireServices();
+        if (!cacheOperation.isTaskSyncEnabled(taskId)) {
             this.plugin.debugLog(`[closeTask] Sync disabled for task ${taskId}, skipping close`);
             this.plugin.logOperation?.log('SYNC_DISABLED_SKIP', `Checkbox close ignored: sync disabled for task ${taskId}`, undefined, taskId);
             return;
         }
         try {
-            const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId);
-            const savedTask = await this.plugin.todoistSyncAPI.GetTaskById(taskId);
+            const taskMapping = cacheOperation.getTaskFileMapping(taskId);
+            const savedTask = await todoistSyncAPI.GetTaskById(taskId);
 
             if (!savedTask) {
-                await this.plugin.cacheOperation.setTaskFileMapping(taskId, taskMapping?.filePath || '', 'issue', false);
-				await this.plugin.cacheOperation.upsertTaskIssue(taskId, 'todoist_task_missing', {
+                await cacheOperation.setTaskFileMapping(taskId, taskMapping?.filePath || '', 'issue', false);
+				await cacheOperation.upsertTaskIssue(taskId, 'todoist_task_missing', {
                     state: 'open',
                     severity: 'high',
                     source: 'runtime',
@@ -616,28 +659,28 @@ export class ObsidianToTodoistSync {
                 const strategy = this.plugin.settings.conflictResolutionStrategy;
                 this.plugin.logOperation?.log('CONFLICT_DETECTED', `Conflict on closeTask ${taskId} (strategy: ${strategy})`, undefined, taskId);
                 if (strategy === 'todoist-wins') {
-                    await this.plugin.cacheOperation.updateTaskMappingSyncMeta(taskId, { updated_at: undefined });
+                    await cacheOperation.updateTaskMappingSyncMeta(taskId, { updated_at: undefined });
                     new Notice(`Conflict on task ${taskId}: Todoist wins — Obsidian will be updated on next sync.`);
                     return;
                 } else if (strategy === 'manual') {
-                    await this.plugin.cacheOperation.setTaskFileMapping(taskId, taskMapping.filePath, 'conflicted', false);
+                    await cacheOperation.setTaskFileMapping(taskId, taskMapping.filePath, 'conflicted', false);
                     new Notice(`Task ${taskId} has a conflict. Sync disabled until resolved.`);
                     return;
                 }
                 // obsidian-wins: fall through and close
             }
 
-            await this.plugin.todoistSyncAPI.CloseTask(taskId);
-			await this.plugin.fileOperation.completeTaskInTheFile(taskId);
+            await todoistSyncAPI.CloseTask(taskId);
+			await fileOperation.completeTaskInTheFile(taskId);
 			const saved = await this.plugin.saveSettings();
 			if (!saved) {
 				console.warn('[closeTask] saveSettings skipped or failed');
 			}
             try {
-                await this.plugin.todoistSyncAPI.incrementalSync();
-                const refreshedTask = await this.plugin.todoistSyncAPI.GetTaskById(taskId);
+                await todoistSyncAPI.incrementalSync();
+                const refreshedTask = await todoistSyncAPI.GetTaskById(taskId);
                 if (refreshedTask?.updated_at) {
-                    await this.plugin.cacheOperation.updateTaskMappingSyncMeta(taskId, { updated_at: refreshedTask.updated_at });
+                    await cacheOperation.updateTaskMappingSyncMeta(taskId, { updated_at: refreshedTask.updated_at });
                 }
             } catch (syncErr) {
                 console.error('[closeTask] Post-push incremental sync failed:', syncErr);
@@ -655,18 +698,19 @@ export class ObsidianToTodoistSync {
             this.plugin.debugLog('[toTodoist] Push blocked: not primary device');
             return;
         }
-        if (!this.plugin.cacheOperation?.isTaskSyncEnabled(taskId)) {
+        const { cacheOperation, todoistSyncAPI, fileOperation } = this.requireServices();
+        if (!cacheOperation.isTaskSyncEnabled(taskId)) {
             this.plugin.debugLog(`[repoenTask] Sync disabled for task ${taskId}, skipping reopen`);
             this.plugin.logOperation?.log('SYNC_DISABLED_SKIP', `Checkbox reopen ignored: sync disabled for task ${taskId}`, undefined, taskId);
             return;
         }
         try {
-            const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId);
-            const savedTask = await this.plugin.todoistSyncAPI.GetTaskById(taskId);
+            const taskMapping = cacheOperation.getTaskFileMapping(taskId);
+            const savedTask = await todoistSyncAPI.GetTaskById(taskId);
 
             if (!savedTask) {
-                await this.plugin.cacheOperation.setTaskFileMapping(taskId, taskMapping?.filePath || '', 'issue', false);
-				await this.plugin.cacheOperation.upsertTaskIssue(taskId, 'todoist_task_missing', {
+                await cacheOperation.setTaskFileMapping(taskId, taskMapping?.filePath || '', 'issue', false);
+				await cacheOperation.upsertTaskIssue(taskId, 'todoist_task_missing', {
                     state: 'open',
                     severity: 'high',
                     source: 'runtime',
@@ -681,28 +725,28 @@ export class ObsidianToTodoistSync {
                 const strategy = this.plugin.settings.conflictResolutionStrategy;
                 this.plugin.logOperation?.log('CONFLICT_DETECTED', `Conflict on repoenTask ${taskId} (strategy: ${strategy})`, undefined, taskId);
                 if (strategy === 'todoist-wins') {
-                    await this.plugin.cacheOperation.updateTaskMappingSyncMeta(taskId, { updated_at: undefined });
+                    await cacheOperation.updateTaskMappingSyncMeta(taskId, { updated_at: undefined });
                     new Notice(`Conflict on task ${taskId}: Todoist wins — Obsidian will be updated on next sync.`);
                     return;
                 } else if (strategy === 'manual') {
-                    await this.plugin.cacheOperation.setTaskFileMapping(taskId, taskMapping.filePath, 'conflicted', false);
+                    await cacheOperation.setTaskFileMapping(taskId, taskMapping.filePath, 'conflicted', false);
                     new Notice(`Task ${taskId} has a conflict. Sync disabled until resolved.`);
                     return;
                 }
                 // obsidian-wins: fall through and reopen
             }
 
-            await this.plugin.todoistSyncAPI.OpenTask(taskId);
-			await this.plugin.fileOperation.uncompleteTaskInTheFile(taskId);
+            await todoistSyncAPI.OpenTask(taskId);
+			await fileOperation.uncompleteTaskInTheFile(taskId);
 			const saved = await this.plugin.saveSettings();
 			if (!saved) {
 				console.warn('[repoenTask] saveSettings skipped or failed');
 			}
             try {
-                await this.plugin.todoistSyncAPI.incrementalSync();
-                const refreshedTask = await this.plugin.todoistSyncAPI.GetTaskById(taskId);
+                await todoistSyncAPI.incrementalSync();
+                const refreshedTask = await todoistSyncAPI.GetTaskById(taskId);
                 if (refreshedTask?.updated_at) {
-                    await this.plugin.cacheOperation.updateTaskMappingSyncMeta(taskId, { updated_at: refreshedTask.updated_at });
+                    await cacheOperation.updateTaskMappingSyncMeta(taskId, { updated_at: refreshedTask.updated_at });
                 }
             } catch (syncErr) {
                 console.error('[repoenTask] Post-push incremental sync failed:', syncErr);
@@ -718,7 +762,8 @@ export class ObsidianToTodoistSync {
 
 
     async updateTaskDescription(filepath: string): Promise<void> {
-        const taskIds = this.plugin.cacheOperation.getTasksInFile(filepath);
+        const { cacheOperation, taskParser, todoistSyncAPI } = this.requireServices();
+        const taskIds = cacheOperation.getTasksInFile(filepath);
 
         if (taskIds.length === 0) {
             return;
@@ -726,16 +771,16 @@ export class ObsidianToTodoistSync {
 
         for (const taskId of taskIds) {
             try {
-                const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId);
+                const taskMapping = cacheOperation.getTaskFileMapping(taskId);
                 if (taskMapping) {
-                    if (!this.plugin.cacheOperation.isTaskSyncEnabled(taskId)) continue;
-                    const description = this.plugin.taskParser.getObsidianUrlFromFilepath(filepath);
-                    const todoistTask = await this.plugin.todoistSyncAPI.GetTaskById(taskId);
+                    if (!cacheOperation.isTaskSyncEnabled(taskId)) continue;
+                    const description = taskParser.getObsidianUrlFromFilepath(filepath);
+                    const todoistTask = await todoistSyncAPI.GetTaskById(taskId);
                     if (todoistTask?.description === description) {
                         continue;
                     }
 
-                    await this.plugin.todoistSyncAPI.UpdateTask(taskId, { description });
+                    await todoistSyncAPI.UpdateTask(taskId, { description });
                     this.plugin.logOperation?.log('TODOIST_TASK_UPDATED', `Updated task description: ${taskId}`, filepath, taskId, 'obsidian→todoist');
                 }
             } catch (error) {

--- a/src/sync/toTodoist.ts
+++ b/src/sync/toTodoist.ts
@@ -229,7 +229,7 @@ export class ObsidianToTodoistSync {
             this.plugin.debugLog('[lastLineNewTaskCheck] Push blocked: not primary device');
             return;
         }
-        const { taskParser, cacheOperation, todoistSyncAPI } = this.requireServices();
+        const { taskParser, cacheOperation, todoistSyncAPI, fileOperation } = this.requireServices();
         if (!this.plugin.settings.enableFullVaultSync) return;
 
         const isTask = taskParser.isMarkdownTask(lineText);
@@ -290,14 +290,14 @@ export class ObsidianToTodoistSync {
             const link = this.plugin.settings.useAppURI ? `[link](todoist://task?id=${newTask.id})` : `[link](https://app.todoist.com/app/task/${newTask.id})`;
             const text = taskParser.addTodoistLink(text_with_out_link, link);
 
-            // Use vault.read + vault.modify since cursor is no longer on this line
-            const file = this.app.vault.getAbstractFileByPath(filepath);
-            const taskFile = this.requireTFile(file, 'lastLineNewTaskCheck');
-            const currentContent = await this.app.vault.read(taskFile);
+            // Read/write through the editor when one is open: the cursor has left
+            // this line, but the buffer is still the authoritative copy and a plain
+            // vault.modify would be undone by the next autosave.
+            const currentContent = await fileOperation.readLiveFileContent(filepath);
             const lines = currentContent.split('\n');
             if (lineNumber < lines.length) {
                 lines[lineNumber] = text;
-                await this.app.vault.modify(taskFile, lines.join('\n'));
+                await fileOperation.writeLiveFileContent(filepath, lines.join('\n'));
             }
 
             const saved = await this.plugin.saveSettings();
@@ -381,7 +381,7 @@ export class ObsidianToTodoistSync {
                         // Atomic: write file immediately after each task
                         const newContent = lines.join('\n');
                         await backupOperation?.backupFile(filepath);
-                        await this.app.vault.modify(file, newContent);
+                        await fileOperation.writeLiveFileContent(filepath, newContent);
 					const saved = await this.plugin.saveSettings();
 					if (!saved) {
 						console.warn('[fullTextNewTaskCheck] saveSettings skipped or failed');
@@ -395,8 +395,9 @@ export class ObsidianToTodoistSync {
                         } catch (syncErr) {
                             console.error('[fullTextNewTaskCheck] Post-push incremental sync failed:', syncErr);
                         }
-                        // Re-read file so subsequent iterations use the latest content
-                        const refreshed = await this.app.vault.read(file);
+                        // Re-read so subsequent iterations use the latest content —
+                        // live, since the write above may have gone to the editor.
+                        const refreshed = await fileOperation.readLiveFileContent(filepath);
                         lines = refreshed.split('\n');
 
                     } catch (error) {

--- a/src/sync/toTodoist.ts
+++ b/src/sync/toTodoist.ts
@@ -45,20 +45,18 @@ export class ObsidianToTodoistSync {
             this.plugin.debugLog('[toTodoist] Push blocked: not primary device');
             return 0;
         }
-        const { cacheOperation, todoistSyncAPI } = this.requireServices();
-        let file;
+        const { cacheOperation, todoistSyncAPI, fileOperation } = this.requireServices();
         let currentFileValue: string;
         let view;
         let filepath: string;
         if (file_path) {
-            file = this.app.vault.getAbstractFileByPath(file_path);
-            file = this.requireTFile(file, 'deletedTaskCheck');
             filepath = file_path;
-            currentFileValue = await this.app.vault.read(file);
+            // Live content, not vault.read: the on-disk copy lags the editor by a
+            // couple of seconds and a just-written todoist_id would look deleted.
+            currentFileValue = await fileOperation.readLiveFileContent(file_path);
         } else {
             view = this.app.workspace.getActiveViewOfType(MarkdownView);
-            file = this.app.workspace.getActiveFile();
-            file = this.requireTFile(file, 'deletedTaskCheck');
+            const file = this.requireTFile(this.app.workspace.getActiveFile(), 'deletedTaskCheck');
             filepath = file.path;
             currentFileValue = view?.data ?? '';
         }
@@ -304,7 +302,9 @@ export class ObsidianToTodoistSync {
             file = this.app.vault.getAbstractFileByPath(file_path);
             file = this.requireTFile(file, 'fullTextNewTaskCheck');
             filepath = file_path;
-            currentFileValue = await this.app.vault.read(file);
+            // Live content: acting on the stale on-disk copy would create a second
+            // Todoist task for a line whose id is still only in the editor buffer.
+            currentFileValue = await fileOperation.readLiveFileContent(file_path);
         } else {
             view = this.app.workspace.getActiveViewOfType(MarkdownView);
             file = this.app.workspace.getActiveFile();
@@ -317,7 +317,9 @@ export class ObsidianToTodoistSync {
         try {
         if (this.plugin.settings.enableFullVaultSync) {
             await fileOperation.addTodoistTagToFile(filepath);
-            currentFileValue = await this.app.vault.read(file);
+            // Live content again: if nothing was tagged, vault.read would hand back
+            // the stale on-disk copy and we would re-create ids already in the editor.
+            currentFileValue = await fileOperation.readLiveFileContent(filepath);
         }
 
             let lines = currentFileValue.split('\n');
@@ -588,7 +590,7 @@ export class ObsidianToTodoistSync {
     }
 
     async fullTextModifiedTaskCheck(file_path: string): Promise<void> {
-        const { taskParser } = this.requireServices();
+        const { taskParser, fileOperation } = this.requireServices();
         let file;
         let currentFileValue;
         let view;
@@ -596,10 +598,8 @@ export class ObsidianToTodoistSync {
 
         try {
             if (file_path) {
-                file = this.app.vault.getAbstractFileByPath(file_path);
-                file = this.requireTFile(file, 'fullTextModifiedTaskCheck');
                 filepath = file_path;
-                currentFileValue = await this.app.vault.read(file);
+                currentFileValue = await fileOperation.readLiveFileContent(file_path);
             } else {
                 view = this.app.workspace.getActiveViewOfType(MarkdownView);
                 file = this.app.workspace.getActiveFile();

--- a/src/sync/toTodoist.ts
+++ b/src/sync/toTodoist.ts
@@ -152,6 +152,22 @@ export class ObsidianToTodoistSync {
             return true;
         });
 
+        // In the limited scope a task that leaves the vault is forgotten here, not
+        // deleted there: the line may have been tidied away while the task is still
+        // being worked on in Todoist.
+        if (this.plugin.settings.obsidianToTodoistScope !== 'full' && tasksToDelete.length > 0) {
+            for (const taskId of tasksToDelete) {
+                await cacheOperation.deleteTaskFileMapping(taskId);
+                this.plugin.logOperation?.log('OBSIDIAN_TASK_DELETED', `Task line removed from vault; kept in Todoist and unlinked: ${taskId}`, filepath, taskId);
+            }
+            new Notice(`${tasksToDelete.length} task(s) removed from this note. They were kept in Todoist.`);
+            const savedUnlink = await this.plugin.saveSettings();
+            if (!savedUnlink) {
+                console.warn('[deletedTaskCheck] saveSettings skipped or failed');
+            }
+            return 0;
+        }
+
         let deletedCount = 0;
         for (const taskId of tasksToDelete) {
             try {
@@ -560,12 +576,18 @@ export class ObsidianToTodoistSync {
                 return;
             }
 
+            // In the limited scope Obsidian creates tasks and reflects completion;
+            // everything after that belongs to Todoist. Not comparing those fields
+            // at all is what keeps a vault line that has drifted from being pushed
+            // over work done in Todoist.
+            const pushesFieldEdits = this.plugin.settings.obsidianToTodoistScope === 'full';
+
             const lineTaskContent = lineTask.content;
-            const contentModified = !taskParser.taskContentCompare(lineTask, savedTask);
-            const tagsModified = !taskParser.taskTagCompare(lineTask, savedTask);
+            const contentModified = pushesFieldEdits && !taskParser.taskContentCompare(lineTask, savedTask);
+            const tagsModified = pushesFieldEdits && !taskParser.taskTagCompare(lineTask, savedTask);
             const statusModified = !taskParser.taskStatusCompare(lineTask, savedTask);
-            const dueDateModified = !taskParser.compareTaskDueDate(lineTask, savedTask);
-            const priorityModified = !taskParser.taskPriorityCompare(lineTask, savedTask);
+            const dueDateModified = pushesFieldEdits && !taskParser.compareTaskDueDate(lineTask, savedTask);
+            const priorityModified = pushesFieldEdits && !taskParser.taskPriorityCompare(lineTask, savedTask);
             const hasLocalChanges = contentModified || tagsModified || statusModified || dueDateModified || priorityModified;
 
             // Conflict detection: Todoist moved on since we last recorded it *and*

--- a/src/sync/toTodoist.ts
+++ b/src/sync/toTodoist.ts
@@ -792,6 +792,8 @@ export class ObsidianToTodoistSync {
             return;
         }
 
+        const updatedTaskIds: string[] = [];
+
         for (const taskId of taskIds) {
             try {
                 const taskMapping = cacheOperation.getTaskFileMapping(taskId);
@@ -804,10 +806,28 @@ export class ObsidianToTodoistSync {
                     }
 
                     await todoistSyncAPI.UpdateTask(taskId, { description });
+                    updatedTaskIds.push(taskId);
                     this.plugin.logOperation?.log('TODOIST_TASK_UPDATED', `Updated task description: ${taskId}`, filepath, taskId, 'obsidian→todoist');
                 }
             } catch (error) {
                 console.error(`Error updating task description for ${taskId}:`, error);
+            }
+        }
+
+        // Each description push bumps the Todoist revision. Without recording the
+        // new value the mapping goes stale and every one of these tasks reports a
+        // phantom conflict on its next edit.
+        if (updatedTaskIds.length > 0) {
+            try {
+                await todoistSyncAPI.incrementalSync();
+                for (const taskId of updatedTaskIds) {
+                    const refreshedTask = todoistSyncAPI.getTaskByIdLocal(taskId);
+                    if (refreshedTask?.updated_at) {
+                        await cacheOperation.updateTaskMappingSyncMeta(taskId, { updated_at: refreshedTask.updated_at });
+                    }
+                }
+            } catch (syncErr) {
+                console.error('[updateTaskDescription] Post-push incremental sync failed:', syncErr);
             }
         }
     }

--- a/src/sync/vanishedTaskAction.ts
+++ b/src/sync/vanishedTaskAction.ts
@@ -1,0 +1,69 @@
+/**
+ * What to do about a mapped task that is no longer in the Sync API response.
+ *
+ * A completed task disappears from `/api/v1/sync` items rather than appearing
+ * with checked=true, so "gone from the sync data" means completed, deleted, or
+ * temporarily not-yet-synced — three cases that need very different handling and
+ * used to be collapsed into "Task no longer exists in Todoist. Sync disabled."
+ *
+ * Kept free of imports so it can be unit-tested directly.
+ */
+
+/** What a direct task lookup told us about a task missing from the sync data. */
+export type TaskCompletionState =
+    /** Todoist has it, completed. */
+    | 'completed'
+    /** Todoist has it and it is open — it should not have been missing; treat as transient. */
+    | 'active'
+    /** Todoist returned 404: really gone. */
+    | 'missing'
+    /** The lookup failed (offline, rate limited, auth). Nothing can be concluded. */
+    | 'unknown';
+
+export type VanishedTaskAction =
+    /** Tick the checkbox in the vault, then settle the mapping. */
+    | 'complete-in-vault'
+    /** Both sides already agree it is done; settle the mapping without writing. */
+    | 'settle'
+    /** Really deleted in Todoist: raise the issue and disable sync for it. */
+    | 'flag-missing'
+    /** Do nothing and look again later. */
+    | 'wait';
+
+export type VanishedTaskContext = {
+    completionState: TaskCompletionState;
+    /** Whether the vault line is already ticked. */
+    vaultCompleted: boolean;
+    /** Age of the mapping in ms, or undefined when it was never stamped. */
+    mappingAgeMs?: number;
+    /** Below this age, a task absent from the sync data is assumed to be mid-creation. */
+    creationGraceMs: number;
+};
+
+export function resolveVanishedTask(context: VanishedTaskContext): VanishedTaskAction {
+    const { completionState, vaultCompleted, mappingAgeMs, creationGraceMs } = context;
+
+    // A task created moments ago may simply not be in the sync data yet. Never
+    // draw conclusions inside that window — this is the window in which the
+    // creation write-back and its first incremental sync are still racing.
+    if (mappingAgeMs !== undefined && mappingAgeMs < creationGraceMs) {
+        return 'wait';
+    }
+
+    switch (completionState) {
+        case 'completed':
+            // Todoist says done. Reflect it in the vault if it is not already.
+            return vaultCompleted ? 'settle' : 'complete-in-vault';
+        case 'missing':
+            // Really deleted. A vault line that is already ticked needs no attention;
+            // an open one has lost its Todoist counterpart and does.
+            return vaultCompleted ? 'settle' : 'flag-missing';
+        case 'active':
+            // Todoist has it open, so its absence from the sync data was transient.
+            return 'wait';
+        case 'unknown':
+        default:
+            // Could not ask. Assume nothing rather than disabling a live task.
+            return 'wait';
+    }
+}

--- a/src/vault/editorContentDiff.ts
+++ b/src/vault/editorContentDiff.ts
@@ -1,0 +1,70 @@
+/**
+ * Line-range diffing for sync writes into an open editor.
+ *
+ * Kept free of any `obsidian` import so it can be unit-tested directly; the
+ * editor-facing wrapper lives in FileOperation.applyContentToEditor.
+ */
+
+export type EditorPosition = { line: number; ch: number };
+
+export type EditorRangeEdit = {
+    /** Text to insert. */
+    text: string;
+    from: EditorPosition;
+    /** Omitted for a pure insertion, which inserts at `from`. */
+    to?: EditorPosition;
+};
+
+/**
+ * Smallest single-range edit that turns `oldContent` into `newContent`, or null
+ * when they are already equal.
+ *
+ * Sync writes rebuild the whole file but usually change one line, so trimming the
+ * common prefix and suffix keeps the edit narrow — which is what preserves the
+ * user's cursor, selection and undo history when the write goes to a live editor.
+ */
+export function computeLineRangeEdit(oldContent: string, newContent: string): EditorRangeEdit | null {
+    if (oldContent === newContent) return null;
+
+    const oldLines = oldContent.split('\n');
+    const newLines = newContent.split('\n');
+
+    let start = 0;
+    while (start < oldLines.length && start < newLines.length && oldLines[start] === newLines[start]) {
+        start++;
+    }
+    let oldEnd = oldLines.length - 1;
+    let newEnd = newLines.length - 1;
+    while (oldEnd >= start && newEnd >= start && oldLines[oldEnd] === newLines[newEnd]) {
+        oldEnd--;
+        newEnd--;
+    }
+
+    if (oldEnd < start) {
+        // Pure insertion of newLines[start..newEnd] before line `start`.
+        const inserted = newLines.slice(start, newEnd + 1).join('\n');
+        if (start > oldLines.length - 1) {
+            // Appending past the last line: attach to the end of it instead, since
+            // line `start` does not exist yet.
+            const lastLine = oldLines.length - 1;
+            return { text: `\n${inserted}`, from: { line: lastLine, ch: oldLines[lastLine].length } };
+        }
+        return { text: `${inserted}\n`, from: { line: start, ch: 0 } };
+    }
+
+    const from: EditorPosition = { line: start, ch: 0 };
+    const to: EditorPosition = { line: oldEnd, ch: oldLines[oldEnd].length };
+
+    if (newEnd < start) {
+        // Pure deletion — also consume the newline that joined the removed block.
+        if (oldEnd + 1 < oldLines.length) {
+            return { text: '', from, to: { line: oldEnd + 1, ch: 0 } };
+        }
+        if (start > 0) {
+            return { text: '', from: { line: start - 1, ch: oldLines[start - 1].length }, to };
+        }
+        return { text: '', from, to };
+    }
+
+    return { text: newLines.slice(start, newEnd + 1).join('\n'), from, to };
+}

--- a/src/vault/fileOperation.ts
+++ b/src/vault/fileOperation.ts
@@ -85,6 +85,78 @@ export class FileOperation   {
         return await this.app.vault.read(this.requireFile(filepath));
     }
 
+    /**
+     * Write new content for a file, going through an open editor when there is one.
+     *
+     * vault.modify() writes to disk behind the editor's back. When the file is open
+     * with unsaved changes, Obsidian's next autosave writes the editor buffer over
+     * that write — silently dropping a todoist_id we just wrote, which orphans the
+     * Todoist task and makes the line look unsynced again on the next scan.
+     */
+    async writeLiveFileContent(filepath: string, newContent: string): Promise<void> {
+        const editor = this.getOpenMarkdownView(filepath)?.editor;
+        if (editor) {
+            this.applyContentToEditor(editor, newContent);
+            return;
+        }
+
+        await this.app.vault.modify(this.requireFile(filepath), newContent);
+    }
+
+    /**
+     * Apply new content to an open editor as a minimal line-range replacement, so
+     * the user's cursor, selection and undo history survive a sync write. Sync
+     * writes touch one line at a time, so the replaced range is normally one line.
+     */
+    private applyContentToEditor(editor: Editor, newContent: string): void {
+        const oldContent = editor.getValue();
+        if (oldContent === newContent) return;
+
+        const oldLines = oldContent.split('\n');
+        const newLines = newContent.split('\n');
+
+        // Narrow to the lines that actually differ.
+        let start = 0;
+        while (start < oldLines.length && start < newLines.length && oldLines[start] === newLines[start]) {
+            start++;
+        }
+        let oldEnd = oldLines.length - 1;
+        let newEnd = newLines.length - 1;
+        while (oldEnd >= start && newEnd >= start && oldLines[oldEnd] === newLines[newEnd]) {
+            oldEnd--;
+            newEnd--;
+        }
+
+        if (oldEnd < start) {
+            // Pure insertion of newLines[start..newEnd] before line `start`.
+            const inserted = newLines.slice(start, newEnd + 1).join('\n');
+            const lastLine = editor.lastLine();
+            if (start > lastLine) {
+                editor.replaceRange(`\n${inserted}`, { line: lastLine, ch: editor.getLine(lastLine).length });
+            } else {
+                editor.replaceRange(`${inserted}\n`, { line: start, ch: 0 });
+            }
+            return;
+        }
+
+        const from = { line: start, ch: 0 };
+        const to = { line: oldEnd, ch: oldLines[oldEnd].length };
+
+        if (newEnd < start) {
+            // Pure deletion — also consume the newline that joined the removed block.
+            if (oldEnd + 1 < oldLines.length) {
+                editor.replaceRange('', from, { line: oldEnd + 1, ch: 0 });
+            } else if (start > 0) {
+                editor.replaceRange('', { line: start - 1, ch: oldLines[start - 1].length }, to);
+            } else {
+                editor.replaceRange('', from, to);
+            }
+            return;
+        }
+
+        editor.replaceRange(newLines.slice(start, newEnd + 1).join('\n'), from, to);
+    }
+
 	/**
 	 * Check if a file path should be excluded from Full Vault Sync.
 	 * Excluded: dot-prefix dirs, plugin storage dir, Obsidian templates folder, *.excalidraw.md
@@ -169,7 +241,6 @@ export class FileOperation   {
         const filepath = taskMapping.filePath
     
         // 获取文件对象并更新内容
-        const file = this.requireFile(filepath)
         const content = await this.readLiveFileContent(filepath)
     
         const lines = content.split('\n')
@@ -187,7 +258,7 @@ export class FileOperation   {
         if (modified) {
         const newContent = lines.join('\n')
         await this.plugin.backupOperation?.backupFile(filepath);
-        await this.app.vault.modify(file, newContent)
+        await this.writeLiveFileContent(filepath, newContent)
         this.plugin.logOperation?.log('FILE_TASK_COMPLETED', `Completed task in file: ${taskId}`, filepath, taskId, this.plugin.isSyncingFromTodoist ? 'todoist→obsidian' : 'obsidian→todoist');
         }
     }
@@ -203,7 +274,6 @@ export class FileOperation   {
         const filepath = taskMapping.filePath
     
         // 获取文件对象并更新内容
-        const file = this.requireFile(filepath)
         const content = await this.readLiveFileContent(filepath)
     
         const lines = content.split('\n')
@@ -221,7 +291,7 @@ export class FileOperation   {
         if (modified) {
         const newContent = lines.join('\n')
         await this.plugin.backupOperation?.backupFile(filepath);
-        await this.app.vault.modify(file, newContent)
+        await this.writeLiveFileContent(filepath, newContent)
         this.plugin.logOperation?.log('FILE_TASK_UNCOMPLETED', `Reopened task in file: ${taskId}`, filepath, taskId, this.plugin.isSyncingFromTodoist ? 'todoist→obsidian' : 'obsidian→todoist');
         }
     }
@@ -237,7 +307,6 @@ export class FileOperation   {
             return;
         }
         const filepath = taskMapping.filePath;
-        const file = this.requireFile(filepath);
         const content = await this.readLiveFileContent(filepath);
         const lines = content.split('\n');
         let modified = false;
@@ -264,14 +333,13 @@ export class FileOperation   {
         }
         if (modified) {
             const newContent = lines.join('\n');
-            await this.app.vault.modify(file, newContent);
+            await this.writeLiveFileContent(filepath, newContent);
             this.plugin.logOperation?.log('FILE_TASK_UNBOUND', `Unbound task from file: ${taskId}`, filepath, taskId, 'obsidian→todoist');
         }
     }
     //add #todoist at the end of task line, if full vault sync enabled
     async addTodoistTagToFile(filepath: string) {    
         if (this.isFileExcludedFromSync(filepath)) return;
-        const file = this.requireFile(filepath)
         const content = await this.readLiveFileContent(filepath)
     
         const lines = content.split('\n')
@@ -304,7 +372,7 @@ export class FileOperation   {
             const newContent = lines.join('\n')
             //this.plugin.debugLog(newContent)
             await this.plugin.backupOperation?.backupFile(filepath);
-            await this.app.vault.modify(file, newContent)
+            await this.writeLiveFileContent(filepath, newContent)
             this.plugin.logOperation?.log('FILE_TODOIST_TAG_ADDED', `Added todoist tag to file: ${filepath}`, filepath);
 
         }
@@ -315,7 +383,6 @@ export class FileOperation   {
     //add todoist at the line
     async addTodoistLinkToFile(filepath: string) {    
         // 获取文件对象并更新内容
-        const file = this.requireFile(filepath)
         const content = await this.readLiveFileContent(filepath)
     
         const lines = content.split('\n')
@@ -353,7 +420,7 @@ export class FileOperation   {
             const newContent = lines.join('\n')
             //this.plugin.debugLog(newContent)
             await this.plugin.backupOperation?.backupFile(filepath);
-            await this.app.vault.modify(file, newContent)
+            await this.writeLiveFileContent(filepath, newContent)
 
 
 
@@ -373,7 +440,6 @@ export class FileOperation   {
         const filepath = taskMapping.filePath
     
         // 获取文件对象并更新内容
-        const file = this.requireFile(filepath)
         const content = await this.readLiveFileContent(filepath)
     
         const lines = content.split('\n')
@@ -395,7 +461,7 @@ export class FileOperation   {
         const newContent = lines.join('\n')
         //this.plugin.debugLog(newContent)
         await this.plugin.backupOperation?.backupFile(filepath);
-        await this.app.vault.modify(file, newContent)
+        await this.writeLiveFileContent(filepath, newContent)
         this.plugin.logOperation?.log('FILE_TASK_CONTENT_SYNCED', `Synced task content from Todoist: ${taskId}`, filepath, taskId, this.plugin.isSyncingFromTodoist ? 'todoist→obsidian' : 'obsidian→todoist');
         }
         
@@ -413,7 +479,6 @@ export class FileOperation   {
         const filepath = taskMapping.filePath
     
         // 获取文件对象并更新内容
-        const file = this.requireFile(filepath)
         const content = await this.readLiveFileContent(filepath)
     
         const lines = content.split('\n')
@@ -453,7 +518,7 @@ export class FileOperation   {
         const newContent = lines.join('\n')
         //this.plugin.debugLog(newContent)
         await this.plugin.backupOperation?.backupFile(filepath);
-        await this.app.vault.modify(file, newContent)
+        await this.writeLiveFileContent(filepath, newContent)
         this.plugin.logOperation?.log('FILE_TASK_DUEDATE_SYNCED', `Synced task due date from Todoist: ${taskId}`, filepath, taskId, this.plugin.isSyncingFromTodoist ? 'todoist→obsidian' : 'obsidian→todoist');
         }
         
@@ -476,7 +541,6 @@ export class FileOperation   {
         const filepath = taskMapping.filePath
     
         // 获取文件对象并更新内容
-        const file = this.requireFile(filepath)
         const content = await this.readLiveFileContent(filepath)
     
         const lines = content.split('\n')
@@ -497,7 +561,7 @@ export class FileOperation   {
         const newContent = lines.join('\n')
         //this.plugin.debugLog(newContent)
         await this.plugin.backupOperation?.backupFile(filepath);
-        await this.app.vault.modify(file, newContent)
+        await this.writeLiveFileContent(filepath, newContent)
         this.plugin.logOperation?.log('FILE_TASK_NOTE_ADDED', `Synced task note from Todoist: ${taskId}`, filepath, taskId, this.plugin.isSyncingFromTodoist ? 'todoist→obsidian' : 'obsidian→todoist');
         }
         
@@ -509,7 +573,6 @@ export class FileOperation   {
         if (!taskMapping) return false;
         const filepath = taskMapping.filePath;
 
-        const file = this.requireFile(filepath);
         const fileContent = await this.readLiveFileContent(filepath);
         const lines = fileContent.split('\n');
         let modified = false;
@@ -529,7 +592,7 @@ export class FileOperation   {
         if (modified) {
             const newFileContent = lines.join('\n');
             await this.plugin.backupOperation?.backupFile(filepath);
-            await this.app.vault.modify(file, newFileContent);
+            await this.writeLiveFileContent(filepath, newFileContent);
             this.plugin.logOperation?.log('FILE_TASK_CONTENT_SYNCED', `Synced content from Todoist: ${taskId}`, filepath, taskId, this.plugin.isSyncingFromTodoist ? 'todoist→obsidian' : 'obsidian→todoist');
         }
         return modified;
@@ -540,7 +603,6 @@ export class FileOperation   {
         if (!taskMapping) return false;
         const filepath = taskMapping.filePath;
 
-        const file = this.requireFile(filepath);
         const fileContent = await this.readLiveFileContent(filepath);
         const lines = fileContent.split('\n');
         let modified = false;
@@ -571,7 +633,7 @@ export class FileOperation   {
         if (modified) {
             const newFileContent = lines.join('\n');
             await this.plugin.backupOperation?.backupFile(filepath);
-            await this.app.vault.modify(file, newFileContent);
+            await this.writeLiveFileContent(filepath, newFileContent);
             this.plugin.logOperation?.log('FILE_TASK_DUEDATE_SYNCED', `Synced due date from Todoist: ${taskId}`, filepath, taskId, this.plugin.isSyncingFromTodoist ? 'todoist→obsidian' : 'obsidian→todoist');
         }
         return modified;
@@ -590,7 +652,6 @@ export class FileOperation   {
         if (!taskMapping) return false;
         const filepath = taskMapping.filePath;
 
-        const file = this.requireFile(filepath);
         const fileContent = await this.readLiveFileContent(filepath);
         const lines = fileContent.split('\n');
         let modified = false;
@@ -623,7 +684,7 @@ export class FileOperation   {
         if (modified) {
             const newFileContent = lines.join('\n');
             await this.plugin.backupOperation?.backupFile(filepath);
-            await this.app.vault.modify(file, newFileContent);
+            await this.writeLiveFileContent(filepath, newFileContent);
             this.plugin.logOperation?.log('FILE_TASK_PRIORITY_SYNCED', `Synced priority from Todoist: ${taskId}`, filepath, taskId, this.plugin.isSyncingFromTodoist ? 'todoist→obsidian' : 'obsidian→todoist');
         }
 
@@ -635,7 +696,6 @@ export class FileOperation   {
         if (!taskMapping) return false;
         const filepath = taskMapping.filePath;
 
-        const file = this.requireFile(filepath);
         const fileContent = await this.readLiveFileContent(filepath);
         const lines = fileContent.split('\n');
         let modified = false;
@@ -673,7 +733,7 @@ export class FileOperation   {
         if (modified) {
             const newFileContent = lines.join('\n');
             await this.plugin.backupOperation?.backupFile(filepath);
-            await this.app.vault.modify(file, newFileContent);
+            await this.writeLiveFileContent(filepath, newFileContent);
             this.plugin.logOperation?.log('FILE_TASK_LABELS_SYNCED', `Synced labels from Todoist: ${taskId}`, filepath, taskId, this.plugin.isSyncingFromTodoist ? 'todoist→obsidian' : 'obsidian→todoist');
         }
 
@@ -685,7 +745,6 @@ export class FileOperation   {
         if (!taskMapping) return false;
         const filepath = taskMapping.filePath;
 
-        const file = this.requireFile(filepath);
         const fileContent = await this.readLiveFileContent(filepath);
         const lines = fileContent.split('\n');
         let modified = false;
@@ -706,7 +765,7 @@ export class FileOperation   {
         if (modified) {
             const newFileContent = lines.join('\n');
             await this.plugin.backupOperation?.backupFile(filepath);
-            await this.app.vault.modify(file, newFileContent);
+            await this.writeLiveFileContent(filepath, newFileContent);
             this.plugin.logOperation?.log('FILE_TASK_NOTE_ADDED', `Synced note from Todoist: ${taskId}`, filepath, taskId, this.plugin.isSyncingFromTodoist ? 'todoist→obsidian' : 'obsidian→todoist');
         }
         return modified;
@@ -727,7 +786,6 @@ export class FileOperation   {
 
     //search todoist_id by content
     async searchTodoistIdFromFilePath(filepath: string, searchTerm: string): Promise<string | null> {
-        const file = this.requireFile(filepath)
         const fileContent = await this.readLiveFileContent(filepath)
         const fileLines = fileContent.split('\n');
         let todoistId: string | null = null;
@@ -792,7 +850,6 @@ export class FileOperation   {
     ): Promise<boolean> {
         try {
             console.log(`[updateTaskIdInVault] start file=${filePath} oldId=${oldId} newId=${newId}`);
-            const file = this.requireFile(filePath);
 
             const content = await this.readLiveFileContent(filePath);
             const lines = content.split('\n');
@@ -871,7 +928,7 @@ export class FileOperation   {
             }
             console.log(`[updateTaskIdInVault] backup-success path=${backupPath}`);
 
-            await this.app.vault.modify(file, lines.join('\n'));
+            await this.writeLiveFileContent(filePath, lines.join('\n'));
             console.log(`[updateTaskIdInVault] vault-modify-success oldId=${oldId} newId=${newId} file=${filePath}`);
             
             this.plugin.logOperation?.log(

--- a/src/vault/fileOperation.ts
+++ b/src/vault/fileOperation.ts
@@ -869,6 +869,16 @@ export class FileOperation   {
                 hasChanges = true;
                 console.log('[updateTaskIdInVault] replaced new web url');
             }
+
+            // Todoist's pre-migration URL, camel-cased as showTask. The shape itself
+            // is retired — following one now gets "this link will stop working" —
+            // so swap the whole URL rather than just the id inside it.
+            const legacyShowTaskPattern = new RegExp(`https?://todoist\\.com/showTask\\?id=${oldId}\\b`, 'gi');
+            if (legacyShowTaskPattern.test(line)) {
+                line = line.replace(legacyShowTaskPattern, `https://app.todoist.com/app/task/${newId}`);
+                hasChanges = true;
+                console.log('[updateTaskIdInVault] replaced legacy showTask url');
+            }
             
             if (!hasChanges) {
                 console.warn(`[updateTaskIdInVault] No ID patterns found for ${oldId} in ${filePath}`);

--- a/src/vault/fileOperation.ts
+++ b/src/vault/fileOperation.ts
@@ -1,5 +1,6 @@
 import { App, Editor, MarkdownView, TFile } from 'obsidian';
 import UltimateTodoistSyncForObsidian from "../../main";
+import { computeLineRangeEdit } from './editorContentDiff';
 
 export interface VaultTask {
     taskId: string;
@@ -107,54 +108,18 @@ export class FileOperation   {
      * Apply new content to an open editor as a minimal line-range replacement, so
      * the user's cursor, selection and undo history survive a sync write. Sync
      * writes touch one line at a time, so the replaced range is normally one line.
+     *
+     * The diff itself lives in editorContentDiff.ts and is unit-tested there.
      */
     private applyContentToEditor(editor: Editor, newContent: string): void {
-        const oldContent = editor.getValue();
-        if (oldContent === newContent) return;
+        const edit = computeLineRangeEdit(editor.getValue(), newContent);
+        if (!edit) return;
 
-        const oldLines = oldContent.split('\n');
-        const newLines = newContent.split('\n');
-
-        // Narrow to the lines that actually differ.
-        let start = 0;
-        while (start < oldLines.length && start < newLines.length && oldLines[start] === newLines[start]) {
-            start++;
+        if (edit.to) {
+            editor.replaceRange(edit.text, edit.from, edit.to);
+        } else {
+            editor.replaceRange(edit.text, edit.from);
         }
-        let oldEnd = oldLines.length - 1;
-        let newEnd = newLines.length - 1;
-        while (oldEnd >= start && newEnd >= start && oldLines[oldEnd] === newLines[newEnd]) {
-            oldEnd--;
-            newEnd--;
-        }
-
-        if (oldEnd < start) {
-            // Pure insertion of newLines[start..newEnd] before line `start`.
-            const inserted = newLines.slice(start, newEnd + 1).join('\n');
-            const lastLine = editor.lastLine();
-            if (start > lastLine) {
-                editor.replaceRange(`\n${inserted}`, { line: lastLine, ch: editor.getLine(lastLine).length });
-            } else {
-                editor.replaceRange(`${inserted}\n`, { line: start, ch: 0 });
-            }
-            return;
-        }
-
-        const from = { line: start, ch: 0 };
-        const to = { line: oldEnd, ch: oldLines[oldEnd].length };
-
-        if (newEnd < start) {
-            // Pure deletion — also consume the newline that joined the removed block.
-            if (oldEnd + 1 < oldLines.length) {
-                editor.replaceRange('', from, { line: oldEnd + 1, ch: 0 });
-            } else if (start > 0) {
-                editor.replaceRange('', { line: start - 1, ch: oldLines[start - 1].length }, to);
-            } else {
-                editor.replaceRange('', from, to);
-            }
-            return;
-        }
-
-        editor.replaceRange(newLines.slice(start, newEnd + 1).join('\n'), from, to);
     }
 
 	/**

--- a/src/vault/fileOperation.ts
+++ b/src/vault/fileOperation.ts
@@ -43,6 +43,15 @@ export class FileOperation   {
 
 	}
 
+    private requireFile(filepath: string): TFile {
+        const file = this.app.vault.getAbstractFileByPath(filepath);
+        if (!(file instanceof TFile)) {
+            throw new Error(`File not found: ${filepath}`);
+        }
+
+        return file;
+    }
+
 	/**
 	 * Check if a file path should be excluded from Full Vault Sync.
 	 * Excluded: dot-prefix dirs, plugin storage dir, Obsidian templates folder, *.excalidraw.md
@@ -119,7 +128,7 @@ export class FileOperation   {
      // 完成一个任务，将其标记为已完成
     async completeTaskInTheFile(taskId: string) {
         // 获取任务文件路径
-        const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId)
+        const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId)
         if (!taskMapping) {
             console.error(`Task ${taskId} not found in taskFileMapping`);
             return;
@@ -127,7 +136,7 @@ export class FileOperation   {
         const filepath = taskMapping.filePath
     
         // 获取文件对象并更新内容
-        const file = this.app.vault.getAbstractFileByPath(filepath)
+        const file = this.requireFile(filepath)
         const content = await this.app.vault.read(file)
     
         const lines = content.split('\n')
@@ -135,7 +144,7 @@ export class FileOperation   {
     
         for (let i = 0; i < lines.length; i++) {
         const line = lines[i]
-        if (line.includes(taskId) && this.plugin.taskParser.hasTodoistTag(line)) {
+        if (line.includes(taskId) && this.plugin.taskParser!.hasTodoistTag(line)) {
             lines[i] = line.replace('[ ]', '[x]')
             modified = true
             break
@@ -153,7 +162,7 @@ export class FileOperation   {
     // uncheck 已完成的任务，
     async uncompleteTaskInTheFile(taskId: string) {
         // 获取任务文件路径
-        const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId)
+        const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId)
         if (!taskMapping) {
             console.error(`Task ${taskId} not found in taskFileMapping`);
             return;
@@ -161,7 +170,7 @@ export class FileOperation   {
         const filepath = taskMapping.filePath
     
         // 获取文件对象并更新内容
-        const file = this.app.vault.getAbstractFileByPath(filepath)
+        const file = this.requireFile(filepath)
         const content = await this.app.vault.read(file)
     
         const lines = content.split('\n')
@@ -169,7 +178,7 @@ export class FileOperation   {
     
         for (let i = 0; i < lines.length; i++) {
         const line = lines[i]
-        if (line.includes(taskId) && this.plugin.taskParser.hasTodoistTag(line)) {
+        if (line.includes(taskId) && this.plugin.taskParser!.hasTodoistTag(line)) {
             lines[i] = line.replace(/- \[(x|X)\]/g, '- [ ]');
             modified = true
             break
@@ -189,17 +198,13 @@ export class FileOperation   {
      * The task line remains in the file but is no longer associated with Todoist.
      */
     async unbindTaskInFile(taskId: string): Promise<void> {
-        const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId);
+        const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId);
         if (!taskMapping) {
             console.error(`[FileOperation] unbindTaskInFile: Task ${taskId} not found in taskFileMapping`);
             return;
         }
         const filepath = taskMapping.filePath;
-        const file = this.app.vault.getAbstractFileByPath(filepath);
-        if (!file) {
-            console.error(`[FileOperation] unbindTaskInFile: File not found: ${filepath}`);
-            return;
-        }
+        const file = this.requireFile(filepath);
         const content = await this.app.vault.read(file);
         const lines = content.split('\n');
         let modified = false;
@@ -227,38 +232,34 @@ export class FileOperation   {
         if (modified) {
             const newContent = lines.join('\n');
             await this.app.vault.modify(file, newContent);
-            this.plugin.logOperation?.log('FILE_TASK_UNBOUND', `Unbound task from file: ${taskId}`, filepath, taskId, 'manual');
+            this.plugin.logOperation?.log('FILE_TASK_UNBOUND', `Unbound task from file: ${taskId}`, filepath, taskId, 'obsidian→todoist');
         }
     }
     //add #todoist at the end of task line, if full vault sync enabled
     async addTodoistTagToFile(filepath: string) {    
         if (this.isFileExcludedFromSync(filepath)) return;
-        const file = this.app.vault.getAbstractFileByPath(filepath)
-        if (!file) {
-            this.plugin.debugLog(`[addTodoistTagToFile] File not found: ${filepath}`);
-            return;
-        }
-        const content = await this.app.vault.read(file as TFile)
+        const file = this.requireFile(filepath)
+        const content = await this.app.vault.read(file)
     
         const lines = content.split('\n')
         let modified = false
     
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i]
-            if(!this.plugin.taskParser.isMarkdownTask(line)){
+            if(!this.plugin.taskParser!.isMarkdownTask(line)){
                 //this.plugin.debugLog(line)
                 //this.plugin.debugLog("It is not a markdown task.")
                 continue;
             }
             //if content is empty
-            if(this.plugin.taskParser.getTaskContentFromLineText(line) == ""){
+            if(this.plugin.taskParser!.getTaskContentFromLineText(line) == ""){
                 //this.plugin.debugLog("Line content is empty")
                 continue;
             }
-            if (!this.plugin.taskParser.hasTodoistId(line) && !this.plugin.taskParser.hasTodoistTag(line)) {
+            if (!this.plugin.taskParser!.hasTodoistId(line) && !this.plugin.taskParser!.hasTodoistTag(line)) {
                 //this.plugin.debugLog(line)
                 //this.plugin.debugLog('prepare to add todoist tag')
-                const newLine = this.plugin.taskParser.addTodoistTag(line);
+                const newLine = this.plugin.taskParser!.addTodoistTag(line);
                 //this.plugin.debugLog(newLine)
                 lines[i] = newLine
                 modified = true
@@ -281,7 +282,7 @@ export class FileOperation   {
     //add todoist at the line
     async addTodoistLinkToFile(filepath: string) {    
         // 获取文件对象并更新内容
-        const file = this.app.vault.getAbstractFileByPath(filepath)
+        const file = this.requireFile(filepath)
         const content = await this.app.vault.read(file)
     
         const lines = content.split('\n')
@@ -289,24 +290,24 @@ export class FileOperation   {
     
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i]
-            if (this.plugin.taskParser.hasTodoistId(line) && this.plugin.taskParser.hasTodoistTag(line)) {
-                if(this.plugin.taskParser.hasTodoistLink(line)){
+            if (this.plugin.taskParser!.hasTodoistId(line) && this.plugin.taskParser!.hasTodoistTag(line)) {
+                if(this.plugin.taskParser!.hasTodoistLink(line)){
                     return
                 }
                 this.plugin.debugLog(line)
                 //this.plugin.debugLog('prepare to add todoist link')
-                const taskID = this.plugin.taskParser.getTodoistIdFromLineText(line)
-                const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskID)
+                const taskID = this.plugin.taskParser!.getTodoistIdFromLineText(line)
+                const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskID ?? '')
                 if (!taskMapping) {
                     console.error(`Task ${taskID} not found in taskFileMapping`);
                     continue;
                 }
-                await this.plugin.todoistSyncAPI.GetTaskById(taskID)
+                await this.plugin.todoistSyncAPI!.GetTaskById(taskID ?? '')
                 const todoistLink = this.plugin.settings.useAppURI
                     ? `todoist://task?id=${taskID}`
                     : `https://app.todoist.com/app/task/${taskID}`
                 const link = `[link](${todoistLink})`
-                const newLine = this.plugin.taskParser.addTodoistLink(line,link)
+                const newLine = this.plugin.taskParser!.addTodoistLink(line,link)
                 this.plugin.debugLog(newLine)
                 lines[i] = newLine
                 modified = true
@@ -328,10 +329,10 @@ export class FileOperation   {
 
 
     // sync updated task content  to file
-    async syncUpdatedTaskContentToTheFile(evt:Object) {
+    async syncUpdatedTaskContentToTheFile(evt:any) {
         const taskId = evt.object_id
         // 获取任务文件路径
-        const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId)
+        const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId)
         if (!taskMapping) {
             console.error(`Task ${taskId} not found in taskFileMapping`);
             return;
@@ -339,7 +340,7 @@ export class FileOperation   {
         const filepath = taskMapping.filePath
     
         // 获取文件对象并更新内容
-        const file = this.app.vault.getAbstractFileByPath(filepath)
+        const file = this.requireFile(filepath)
         const content = await this.app.vault.read(file)
     
         const lines = content.split('\n')
@@ -347,8 +348,8 @@ export class FileOperation   {
     
         for (let i = 0; i < lines.length; i++) {
         const line = lines[i]
-        if (line.includes(taskId) && this.plugin.taskParser.hasTodoistTag(line)) {
-            const oldTaskContent = this.plugin.taskParser.getTaskContentFromLineText(line)
+        if (line.includes(taskId) && this.plugin.taskParser!.hasTodoistTag(line)) {
+            const oldTaskContent = this.plugin.taskParser!.getTaskContentFromLineText(line)
             const newTaskContent = evt.extra_data.content
 
             lines[i] = line.replace(oldTaskContent, newTaskContent)
@@ -368,10 +369,10 @@ export class FileOperation   {
     }
 
     // sync updated task due date  to the file
-    async syncUpdatedTaskDueDateToTheFile(evt:Object) {
+    async syncUpdatedTaskDueDateToTheFile(evt:any) {
         const taskId = evt.object_id
         // 获取任务文件路径
-        const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId)
+        const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId)
         if (!taskMapping) {
             console.error(`Task ${taskId} not found in taskFileMapping`);
             return;
@@ -379,7 +380,7 @@ export class FileOperation   {
         const filepath = taskMapping.filePath
     
         // 获取文件对象并更新内容
-        const file = this.app.vault.getAbstractFileByPath(filepath)
+        const file = this.requireFile(filepath)
         const content = await this.app.vault.read(file)
     
         const lines = content.split('\n')
@@ -387,16 +388,16 @@ export class FileOperation   {
     
         for (let i = 0; i < lines.length; i++) {
         const line = lines[i]
-        if (line.includes(taskId) && this.plugin.taskParser.hasTodoistTag(line)) {
-            const oldTaskDueDate = this.plugin.taskParser.getDueDateFromLineText(line) || ""
-            const newTaskDueDate = this.plugin.taskParser.ISOStringToLocalDateString(evt.extra_data.due_date) || ""
+        if (line.includes(taskId) && this.plugin.taskParser!.hasTodoistTag(line)) {
+            const oldTaskDueDate = this.plugin.taskParser!.getDueDateFromLineText(line) || ""
+            const newTaskDueDate = this.plugin.taskParser!.ISOStringToLocalDateString(evt.extra_data.due_date) || ""
             
             //this.plugin.debugLog(`${taskId} duedate is updated`)
             this.plugin.debugLog(oldTaskDueDate)
             this.plugin.debugLog(newTaskDueDate)
             if(oldTaskDueDate === ""){
-                //this.plugin.debugLog(this.plugin.taskParser.insertDueDateBeforeTodoist(line,newTaskDueDate))
-                lines[i] = this.plugin.taskParser.insertDueDateBeforeTodoist(line,newTaskDueDate)
+                //this.plugin.debugLog(this.plugin.taskParser!.insertDueDateBeforeTodoist(line,newTaskDueDate))
+                lines[i] = this.plugin.taskParser!.insertDueDateBeforeTodoist(line,newTaskDueDate)
                 modified = true
 
             }
@@ -427,14 +428,14 @@ export class FileOperation   {
 
 
     // sync new task note to file
-    async syncAddedTaskNoteToTheFile(evt:Object) {
+    async syncAddedTaskNoteToTheFile(evt:any) {
 
 
         const taskId = evt.parent_item_id
         const note = evt.extra_data.content
-        const datetime = this.plugin.taskParser.ISOStringToLocalDatetimeString(evt.event_date)
+        const datetime = this.plugin.taskParser!.ISOStringToLocalDatetimeString(evt.event_date)
         // 获取任务文件路径
-        const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId)
+        const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId)
         if (!taskMapping) {
             console.error(`Task ${taskId} not found in taskFileMapping`);
             return;
@@ -442,7 +443,7 @@ export class FileOperation   {
         const filepath = taskMapping.filePath
     
         // 获取文件对象并更新内容
-        const file = this.app.vault.getAbstractFileByPath(filepath)
+        const file = this.requireFile(filepath)
         const content = await this.app.vault.read(file)
     
         const lines = content.split('\n')
@@ -450,7 +451,7 @@ export class FileOperation   {
     
         for (let i = 0; i < lines.length; i++) {
         const line = lines[i]
-        if (line.includes(taskId) && this.plugin.taskParser.hasTodoistTag(line)) {
+        if (line.includes(taskId) && this.plugin.taskParser!.hasTodoistTag(line)) {
             const indent = '\t'.repeat(line.length - line.trimStart().length + 1);
             const noteLine = `${indent}- ${datetime} ${note}`;
             lines.splice(i + 1, 0, noteLine);
@@ -471,19 +472,19 @@ export class FileOperation   {
 
 
     async syncTaskContentToFile(taskId: string, newContent: string): Promise<boolean> {
-        const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId);
+        const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId);
         if (!taskMapping) return false;
         const filepath = taskMapping.filePath;
 
-        const file = this.app.vault.getAbstractFileByPath(filepath);
+        const file = this.requireFile(filepath);
         const fileContent = await this.app.vault.read(file);
         const lines = fileContent.split('\n');
         let modified = false;
 
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i];
-            if (line.includes(taskId) && this.plugin.taskParser.hasTodoistTag(line)) {
-                const oldContent = this.plugin.taskParser.getTaskContentFromLineText(line);
+            if (line.includes(taskId) && this.plugin.taskParser!.hasTodoistTag(line)) {
+                const oldContent = this.plugin.taskParser!.getTaskContentFromLineText(line);
                 if (oldContent && oldContent !== newContent) {
                     lines[i] = line.replace(oldContent, newContent);
                     modified = true;
@@ -502,25 +503,25 @@ export class FileOperation   {
     }
 
     async syncTaskDueDateToFile(taskId: string, newDueDate: string): Promise<boolean> {
-        const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId);
+        const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId);
         if (!taskMapping) return false;
         const filepath = taskMapping.filePath;
 
-        const file = this.app.vault.getAbstractFileByPath(filepath);
+        const file = this.requireFile(filepath);
         const fileContent = await this.app.vault.read(file);
         const lines = fileContent.split('\n');
         let modified = false;
 
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i];
-            if (line.includes(taskId) && this.plugin.taskParser.hasTodoistTag(line)) {
-                const oldDueDate = this.plugin.taskParser.getDueDateFromLineText(line) || "";
-                const localDueDate = this.plugin.taskParser.ISOStringToLocalDateString(newDueDate) || "";
+            if (line.includes(taskId) && this.plugin.taskParser!.hasTodoistTag(line)) {
+                const oldDueDate = this.plugin.taskParser!.getDueDateFromLineText(line) || "";
+                const localDueDate = this.plugin.taskParser!.ISOStringToLocalDateString(newDueDate) || "";
 
                 if (oldDueDate === localDueDate) break;
 
                 if (oldDueDate === "" && localDueDate !== "") {
-                    lines[i] = this.plugin.taskParser.insertDueDateBeforeTodoist(line, localDueDate);
+                    lines[i] = this.plugin.taskParser!.insertDueDateBeforeTodoist(line, localDueDate);
                     modified = true;
                 } else if (localDueDate === "") {
                     const regexRemoveDate = /(🗓️|📅|📆|🗓)\s?\d{4}-\d{2}-\d{2}/;
@@ -552,11 +553,11 @@ export class FileOperation   {
     }
 
     async syncTaskPriorityToFile(taskId: string, newPriority: number): Promise<boolean> {
-        const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId);
+        const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId);
         if (!taskMapping) return false;
         const filepath = taskMapping.filePath;
 
-        const file = this.app.vault.getAbstractFileByPath(filepath);
+        const file = this.requireFile(filepath);
         const fileContent = await this.app.vault.read(file);
         const lines = fileContent.split('\n');
         let modified = false;
@@ -568,9 +569,9 @@ export class FileOperation   {
 
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i];
-            if (!line.includes(taskId) || !this.plugin.taskParser.hasTodoistTag(line)) continue;
+            if (!line.includes(taskId) || !this.plugin.taskParser!.hasTodoistTag(line)) continue;
 
-            const currentPriority = this.plugin.taskParser.getTaskPriority(line);
+            const currentPriority = this.plugin.taskParser!.getTaskPriority(line);
             if (currentPriority === targetPriority) break;
 
             const metadataIndex = line.indexOf('%%[todoist_id::');
@@ -597,24 +598,24 @@ export class FileOperation   {
     }
 
     async syncTaskLabelsToFile(taskId: string, newLabels: string[]): Promise<boolean> {
-        const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId);
+        const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId);
         if (!taskMapping) return false;
         const filepath = taskMapping.filePath;
 
-        const file = this.app.vault.getAbstractFileByPath(filepath);
+        const file = this.requireFile(filepath);
         const fileContent = await this.app.vault.read(file);
         const lines = fileContent.split('\n');
         let modified = false;
 
         const todoistLabels = this.normalizeLabelsForSync(newLabels);
-        const desiredLabels = this.plugin.taskParser.normalizeLabelsForCompare([...todoistLabels, 'todoist']);
+        const desiredLabels = this.plugin.taskParser!.normalizeLabelsForCompare([...todoistLabels, 'todoist']);
 
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i];
-            if (!line.includes(taskId) || !this.plugin.taskParser.hasTodoistTag(line)) continue;
+            if (!line.includes(taskId) || !this.plugin.taskParser!.hasTodoistTag(line)) continue;
 
-            const currentLabels = this.plugin.taskParser.normalizeLabelsForCompare(
-                this.plugin.taskParser.getAllTagsFromLineText(line)
+            const currentLabels = this.plugin.taskParser!.normalizeLabelsForCompare(
+                this.plugin.taskParser!.getAllTagsFromLineText(line)
             );
             const isSame = currentLabels.length === desiredLabels.length
                 && currentLabels.every((label, idx) => label === desiredLabels[idx]);
@@ -647,18 +648,18 @@ export class FileOperation   {
     }
 
     async syncTaskNoteToFile(taskId: string, noteContent: string, noteDate: string): Promise<boolean> {
-        const taskMapping = this.plugin.cacheOperation.getTaskFileMapping(taskId);
+        const taskMapping = this.plugin.cacheOperation!.getTaskFileMapping(taskId);
         if (!taskMapping) return false;
         const filepath = taskMapping.filePath;
 
-        const file = this.app.vault.getAbstractFileByPath(filepath);
+        const file = this.requireFile(filepath);
         const fileContent = await this.app.vault.read(file);
         const lines = fileContent.split('\n');
         let modified = false;
 
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i];
-            if (line.includes(taskId) && this.plugin.taskParser.hasTodoistTag(line)) {
+            if (line.includes(taskId) && this.plugin.taskParser!.hasTodoistTag(line)) {
                 const indent = '\t'.repeat(line.length - line.trimStart().length + 1);
                 const noteLine = `${indent}- ${noteDate} ${noteContent}`;
                 // skip if note already exists in next lines
@@ -681,7 +682,7 @@ export class FileOperation   {
     //避免使用该方式，通过view可以获得实时更新的value
     async readContentFromFilePath(filepath:string){
         try {
-            const file = this.app.vault.getAbstractFileByPath(filepath);
+            const file = this.requireFile(filepath);
             const content = await this.app.vault.read(file);
             return content
         } catch (error) {
@@ -693,7 +694,7 @@ export class FileOperation   {
 
     //search todoist_id by content
     async searchTodoistIdFromFilePath(filepath: string, searchTerm: string): Promise<string | null> {
-        const file = this.app.vault.getAbstractFileByPath(filepath)
+        const file = this.requireFile(filepath)
         const fileContent = await this.app.vault.read(file)
         const fileLines = fileContent.split('\n');
         let todoistId: string | null = null;
@@ -744,18 +745,8 @@ export class FileOperation   {
 
 
     isMarkdownFile(filename:string) {
-        // 获取文件名的扩展名
-        let extension = filename.split('.').pop();
-      
-        // 将扩展名转换为小写（Markdown文件的扩展名通常是.md）
-        extension = extension.toLowerCase();
-      
-        // 判断扩展名是否为.md
-        if (extension === 'md') {
-          return true;
-        } else {
-          return false;
-        }
+        const extension = filename.split('.').pop();
+        return extension?.toLowerCase() === 'md';
       }
 
     /**
@@ -768,13 +759,7 @@ export class FileOperation   {
     ): Promise<boolean> {
         try {
             console.log(`[updateTaskIdInVault] start file=${filePath} oldId=${oldId} newId=${newId}`);
-            const file = this.app.vault.getAbstractFileByPath(filePath);
-            if (!file) {
-                console.error(`[updateTaskIdInVault] File not found: ${filePath}`);
-                this.plugin.debugLog(filePath)
-                console.log(`[updateTaskIdInVault] fail file-not-found file=${filePath}`);
-                return false;
-            }
+            const file = this.requireFile(filePath);
             
             const content = await this.app.vault.read(file);
             const lines = content.split('\n');
@@ -910,11 +895,11 @@ export class FileOperation   {
                     }
                     
                     const match = line.match(/%%\[todoist_id::\s*([\w-]+)\]%%/);
-                        const taskContent = this.plugin.taskParser.getTaskContentFromLineText(line);
+                        const taskContent = this.plugin.taskParser!.getTaskContentFromLineText(line);
                         const isCompleted = /\[x\]/i.test(line);
                         const labels = this.extractLabelsFromLine(line);
-                        const dueDate = this.plugin.taskParser.getDueDateFromLineText(line) || undefined;
-                        const priority = this.plugin.taskParser.getTaskPriority(line);
+                        const dueDate = this.plugin.taskParser!.getDueDateFromLineText(line) || undefined;
+                        const priority = this.plugin.taskParser!.getTaskPriority(line);
                     
                     if (match && match[1]) {
                         const taskId = match[1];
@@ -991,7 +976,7 @@ export class FileOperation   {
      * @returns 标签数组（不带 # 前缀）
      */
     private extractLabelsFromLine(line: string): string[] {
-        return this.plugin.taskParser.getAllTagsFromLineText(line);
+        return this.plugin.taskParser!.getAllTagsFromLineText(line);
     }
 
 

--- a/src/vault/fileOperation.ts
+++ b/src/vault/fileOperation.ts
@@ -1,4 +1,4 @@
-import { App, TFile } from 'obsidian';
+import { App, Editor, MarkdownView, TFile } from 'obsidian';
 import UltimateTodoistSyncForObsidian from "../../main";
 
 export interface VaultTask {
@@ -50,6 +50,39 @@ export class FileOperation   {
         }
 
         return file;
+    }
+
+    /**
+     * The markdown view currently showing this file, if any.
+     */
+    getOpenMarkdownView(filepath: string): MarkdownView | null {
+        for (const leaf of this.app.workspace.getLeavesOfType('markdown')) {
+            const view = leaf.view;
+            if (view instanceof MarkdownView && view.file?.path === filepath) {
+                return view;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Read the *current* content of a file, preferring an open editor's buffer
+     * over the on-disk copy.
+     *
+     * Obsidian flushes the editor to disk only after a couple of seconds of idle,
+     * so vault.read() returns stale text while the user is typing. Acting on that
+     * stale text is destructive: a todoist_id written back into the editor moments
+     * ago looks missing, which makes deletedTaskCheck delete the brand-new Todoist
+     * task and makes fullTextNewTaskCheck create a duplicate for the same line.
+     */
+    async readLiveFileContent(filepath: string): Promise<string> {
+        const view = this.getOpenMarkdownView(filepath);
+        if (view) {
+            return view.editor?.getValue() ?? view.data;
+        }
+
+        return await this.app.vault.read(this.requireFile(filepath));
     }
 
 	/**
@@ -137,7 +170,7 @@ export class FileOperation   {
     
         // 获取文件对象并更新内容
         const file = this.requireFile(filepath)
-        const content = await this.app.vault.read(file)
+        const content = await this.readLiveFileContent(filepath)
     
         const lines = content.split('\n')
         let modified = false
@@ -171,7 +204,7 @@ export class FileOperation   {
     
         // 获取文件对象并更新内容
         const file = this.requireFile(filepath)
-        const content = await this.app.vault.read(file)
+        const content = await this.readLiveFileContent(filepath)
     
         const lines = content.split('\n')
         let modified = false
@@ -205,7 +238,7 @@ export class FileOperation   {
         }
         const filepath = taskMapping.filePath;
         const file = this.requireFile(filepath);
-        const content = await this.app.vault.read(file);
+        const content = await this.readLiveFileContent(filepath);
         const lines = content.split('\n');
         let modified = false;
         for (let i = 0; i < lines.length; i++) {
@@ -239,7 +272,7 @@ export class FileOperation   {
     async addTodoistTagToFile(filepath: string) {    
         if (this.isFileExcludedFromSync(filepath)) return;
         const file = this.requireFile(filepath)
-        const content = await this.app.vault.read(file)
+        const content = await this.readLiveFileContent(filepath)
     
         const lines = content.split('\n')
         let modified = false
@@ -283,7 +316,7 @@ export class FileOperation   {
     async addTodoistLinkToFile(filepath: string) {    
         // 获取文件对象并更新内容
         const file = this.requireFile(filepath)
-        const content = await this.app.vault.read(file)
+        const content = await this.readLiveFileContent(filepath)
     
         const lines = content.split('\n')
         let modified = false
@@ -341,7 +374,7 @@ export class FileOperation   {
     
         // 获取文件对象并更新内容
         const file = this.requireFile(filepath)
-        const content = await this.app.vault.read(file)
+        const content = await this.readLiveFileContent(filepath)
     
         const lines = content.split('\n')
         let modified = false
@@ -381,7 +414,7 @@ export class FileOperation   {
     
         // 获取文件对象并更新内容
         const file = this.requireFile(filepath)
-        const content = await this.app.vault.read(file)
+        const content = await this.readLiveFileContent(filepath)
     
         const lines = content.split('\n')
         let modified = false
@@ -444,7 +477,7 @@ export class FileOperation   {
     
         // 获取文件对象并更新内容
         const file = this.requireFile(filepath)
-        const content = await this.app.vault.read(file)
+        const content = await this.readLiveFileContent(filepath)
     
         const lines = content.split('\n')
         let modified = false
@@ -477,7 +510,7 @@ export class FileOperation   {
         const filepath = taskMapping.filePath;
 
         const file = this.requireFile(filepath);
-        const fileContent = await this.app.vault.read(file);
+        const fileContent = await this.readLiveFileContent(filepath);
         const lines = fileContent.split('\n');
         let modified = false;
 
@@ -508,7 +541,7 @@ export class FileOperation   {
         const filepath = taskMapping.filePath;
 
         const file = this.requireFile(filepath);
-        const fileContent = await this.app.vault.read(file);
+        const fileContent = await this.readLiveFileContent(filepath);
         const lines = fileContent.split('\n');
         let modified = false;
 
@@ -558,7 +591,7 @@ export class FileOperation   {
         const filepath = taskMapping.filePath;
 
         const file = this.requireFile(filepath);
-        const fileContent = await this.app.vault.read(file);
+        const fileContent = await this.readLiveFileContent(filepath);
         const lines = fileContent.split('\n');
         let modified = false;
 
@@ -603,7 +636,7 @@ export class FileOperation   {
         const filepath = taskMapping.filePath;
 
         const file = this.requireFile(filepath);
-        const fileContent = await this.app.vault.read(file);
+        const fileContent = await this.readLiveFileContent(filepath);
         const lines = fileContent.split('\n');
         let modified = false;
 
@@ -653,7 +686,7 @@ export class FileOperation   {
         const filepath = taskMapping.filePath;
 
         const file = this.requireFile(filepath);
-        const fileContent = await this.app.vault.read(file);
+        const fileContent = await this.readLiveFileContent(filepath);
         const lines = fileContent.split('\n');
         let modified = false;
 
@@ -695,7 +728,7 @@ export class FileOperation   {
     //search todoist_id by content
     async searchTodoistIdFromFilePath(filepath: string, searchTerm: string): Promise<string | null> {
         const file = this.requireFile(filepath)
-        const fileContent = await this.app.vault.read(file)
+        const fileContent = await this.readLiveFileContent(filepath)
         const fileLines = fileContent.split('\n');
         let todoistId: string | null = null;
     
@@ -760,8 +793,8 @@ export class FileOperation   {
         try {
             console.log(`[updateTaskIdInVault] start file=${filePath} oldId=${oldId} newId=${newId}`);
             const file = this.requireFile(filePath);
-            
-            const content = await this.app.vault.read(file);
+
+            const content = await this.readLiveFileContent(filePath);
             const lines = content.split('\n');
             console.log(`[updateTaskIdInVault] file-loaded lines=${lines.length} file=${filePath}`);
             
@@ -884,7 +917,7 @@ export class FileOperation   {
 
         for (const file of files) {
             try {
-                const content = await this.app.vault.read(file);
+                const content = await this.readLiveFileContent(file.path);
                 const lines = content.split('\n');
 
                 for (let i = 0; i < lines.length; i++) {

--- a/tests/unit/editorContentDiff.test.mjs
+++ b/tests/unit/editorContentDiff.test.mjs
@@ -10,7 +10,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { computeLineRangeEdit } from '../.build/editorContentDiff.mjs';
+import { computeLineRangeEdit } from '../.build/vault/editorContentDiff.mjs';
 
 /** Minimal stand-in for Obsidian's Editor, strict about out-of-range positions. */
 class FakeEditor {

--- a/tests/unit/editorContentDiff.test.mjs
+++ b/tests/unit/editorContentDiff.test.mjs
@@ -1,0 +1,124 @@
+// Unit tests for computeLineRangeEdit (src/vault/editorContentDiff.ts).
+//
+// Run with `npm test`, which compiles the module under test to tests/.build first.
+//
+// Sync writes go through an open editor as a single range replacement, so a wrong
+// range silently corrupts the user's note. Every case here asserts two things:
+// applying the edit reproduces the target content exactly, and the positions it
+// reports are in range for the document it is applied to.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { computeLineRangeEdit } from '../.build/editorContentDiff.mjs';
+
+/** Minimal stand-in for Obsidian's Editor, strict about out-of-range positions. */
+class FakeEditor {
+	constructor(text) {
+		this.text = text;
+	}
+
+	getValue() {
+		return this.text;
+	}
+
+	#offset(pos, label) {
+		const lines = this.text.split('\n');
+		assert.ok(
+			pos.line >= 0 && pos.line < lines.length,
+			`${label}.line ${pos.line} out of range (0..${lines.length - 1})`
+		);
+		assert.ok(
+			pos.ch >= 0 && pos.ch <= lines[pos.line].length,
+			`${label}.ch ${pos.ch} out of range on line ${pos.line} (0..${lines[pos.line].length})`
+		);
+		let offset = 0;
+		for (let i = 0; i < pos.line; i++) offset += lines[i].length + 1;
+		return offset + pos.ch;
+	}
+
+	replaceRange(replacement, from, to) {
+		const start = this.#offset(from, 'from');
+		const end = to === undefined ? start : this.#offset(to, 'to');
+		assert.ok(end >= start, 'to must not precede from');
+		this.text = this.text.slice(0, start) + replacement + this.text.slice(end);
+	}
+}
+
+function applyEdit(oldContent, newContent) {
+	const editor = new FakeEditor(oldContent);
+	const edit = computeLineRangeEdit(oldContent, newContent);
+	if (edit) editor.replaceRange(edit.text, edit.from, edit.to);
+	return editor.getValue();
+}
+
+function assertRoundTrip(oldContent, newContent, label) {
+	assert.equal(applyEdit(oldContent, newContent), newContent, label);
+}
+
+const TASK = '- [ ] buy milk #todoist';
+const TASK_WITH_ID = '- [ ] buy milk [link](todoist://task?id=1) #todoist %%[todoist_id:: 1]%%';
+
+test('returns null when content is unchanged', () => {
+	assert.equal(computeLineRangeEdit('a\nb', 'a\nb'), null);
+});
+
+test('writes a todoist_id back onto the task line', () => {
+	assertRoundTrip(TASK, TASK_WITH_ID, 'single-line document');
+	assertRoundTrip(`# Notes\n${TASK}\ntail`, `# Notes\n${TASK_WITH_ID}\ntail`, 'mid document');
+	assertRoundTrip(`# Notes\n${TASK}`, `# Notes\n${TASK_WITH_ID}`, 'last line');
+	assertRoundTrip(`${TASK}\ntail`, `${TASK_WITH_ID}\ntail`, 'first line');
+});
+
+test('touches only the changed line', () => {
+	const edit = computeLineRangeEdit('a\n- [ ] x\nb', 'a\n- [x] x\nb');
+	assert.deepEqual(edit.from, { line: 1, ch: 0 });
+	assert.deepEqual(edit.to, { line: 1, ch: '- [ ] x'.length });
+	assert.equal(edit.text, '- [x] x');
+});
+
+test('inserts lines (note sync)', () => {
+	assertRoundTrip('a\n- [ ] x\nb', 'a\n- [ ] x\n\t- note\nb', 'after a middle line');
+	assertRoundTrip('a\n- [ ] x', 'a\n- [ ] x\n\t- note', 'after the last line');
+	assertRoundTrip('a\nb', 'new\na\nb', 'at the very start');
+	assertRoundTrip('a\nb', 'a\nX\nY\nb', 'two lines at once');
+	assertRoundTrip('', 'a\nb', 'into an empty document');
+	assertRoundTrip('a', 'a\n', 'trailing blank line');
+});
+
+test('deletes lines', () => {
+	assertRoundTrip('a\nX\nb', 'a\nb', 'from the middle');
+	assertRoundTrip('a\nX', 'a', 'the last line');
+	assertRoundTrip('X\na', 'a', 'the first line');
+	assertRoundTrip('X\nY\nZ', 'Y', 'all but one');
+	assertRoundTrip('a\nb', '', 'the whole document');
+	assertRoundTrip('a\n', 'a', 'trailing blank line');
+	assertRoundTrip('a', '', 'a single-line document');
+});
+
+test('handles repeated lines without drifting', () => {
+	assertRoundTrip('x\nx\nx', 'x\ny\nx', 'middle changed');
+	assertRoundTrip('x\nx\nx', 'x\nx', 'one removed');
+	assertRoundTrip('x\nx', 'x\nx\nx', 'one added');
+});
+
+test('replaces wholesale when nothing is in common', () => {
+	assertRoundTrip('a\nb\nc', 'x\ny\nz');
+});
+
+test('round-trips randomised document pairs', () => {
+	const alphabet = ['a', 'b', 'c', '', '- [ ] t #todoist', '\t- note'];
+	const pick = (n) => Math.floor(Math.random() * n);
+	const randomDoc = () =>
+		Array.from({ length: pick(6) }, () => alphabet[pick(alphabet.length)]).join('\n');
+
+	for (let i = 0; i < 20000; i++) {
+		const oldContent = randomDoc();
+		const newContent = randomDoc();
+		assert.equal(
+			applyEdit(oldContent, newContent),
+			newContent,
+			`iteration ${i}: ${JSON.stringify(oldContent)} -> ${JSON.stringify(newContent)}`
+		);
+	}
+});

--- a/tests/unit/taskContent.test.mjs
+++ b/tests/unit/taskContent.test.mjs
@@ -1,0 +1,76 @@
+// Unit tests for stripTaskContent (src/data/taskContent.ts).
+//
+// Run with `npm test`.
+//
+// This is what a vault line is reduced to before being compared with Todoist.
+// Anything left behind reads as a local edit, so the line gets pushed — or, with
+// a revision mismatch, reported as a conflict on a task nobody touched.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { stripTaskContent } from '../.build/data/taskContent.mjs';
+
+const ID = '6X7rfFVPjhLTMwsz';
+const META = `%%[todoist_id:: ${ID}]%%`;
+
+test('strips checkbox, tag and id metadata', () => {
+	assert.equal(stripTaskContent(`- [ ] buy milk #todoist ${META}`), 'buy milk');
+	assert.equal(stripTaskContent(`- [x] buy milk #todoist ${META}`), 'buy milk');
+	assert.equal(stripTaskContent(`\t- [ ] buy milk #todoist ${META}`), 'buy milk');
+});
+
+test('strips every link format the plugin has written', () => {
+	const links = [
+		// Todoist's pre-migration URL is camel-cased; a lowercase-only pattern
+		// missed it and left the whole link in the compared content.
+		`[link](https://todoist.com/showTask?id=12345)`,
+		`[link](https://Todoist.com/ShowTask?id=12345)`,
+		`[link](https://app.todoist.com/app/task/${ID})`,
+		`[link](https://app.todoist.com/app/task/buy-milk-${ID})`,
+		`[link](https://todoist.com/app/task/12345)`,
+		`[link](https://todoist.com/showtask?id=12345)`,
+		`[link](todoist://task?id=${ID})`,
+	];
+	for (const link of links) {
+		assert.equal(stripTaskContent(`- [ ] buy milk ${link} #todoist ${META}`), 'buy milk', link);
+	}
+});
+
+test('strips repeated links and id blocks on one line', () => {
+	// Older builds could process a line twice, leaving two of each. A non-global
+	// strip kept the second one in the compared text, which read as an edit.
+	const link = `[link](https://app.todoist.com/app/task/${ID})`;
+	assert.equal(stripTaskContent(`- [ ] buy milk ${link} ${link} #todoist ${META}`), 'buy milk');
+	assert.equal(stripTaskContent(`- [ ] buy milk ${link} #todoist ${META} ${META}`), 'buy milk');
+	assert.equal(
+		stripTaskContent(`- [ ] buy milk [link](https://todoist.com/showtask?id=1) ${link} #todoist ${META}`),
+		'buy milk'
+	);
+});
+
+test('strips a bare task URL written without markdown', () => {
+	assert.equal(stripTaskContent(`- [ ] buy milk https://app.todoist.com/app/task/${ID} #todoist ${META}`), 'buy milk');
+	assert.equal(stripTaskContent(`- [ ] buy milk todoist://task?id=${ID} #todoist ${META}`), 'buy milk');
+});
+
+test('leaves unrelated links and text alone', () => {
+	assert.equal(
+		stripTaskContent(`- [ ] read [the docs](https://example.com/todoist) #todoist ${META}`),
+		'read [the docs](https://example.com/todoist)'
+	);
+	assert.equal(stripTaskContent('- [ ] buy milk'), 'buy milk');
+});
+
+test('strips due date and priority markers', () => {
+	assert.equal(stripTaskContent(`- [ ] buy milk 📅 2026-01-01 #todoist ${META}`), 'buy milk');
+	assert.equal(stripTaskContent(`- [ ] buy milk !!4 #todoist ${META}`), 'buy milk');
+	assert.equal(stripTaskContent(`- [ ] buy milk 🗓️ 2026-01-01 !!2 #todoist ${META}`), 'buy milk');
+});
+
+test('is stable when applied twice', () => {
+	// Content read back from a line the plugin wrote must equal what it pushed.
+	const line = `- [ ] buy milk [link](https://app.todoist.com/app/task/${ID}) #todoist ${META}`;
+	const once = stripTaskContent(line);
+	assert.equal(stripTaskContent(once), once);
+});

--- a/tests/unit/vanishedTaskAction.test.mjs
+++ b/tests/unit/vanishedTaskAction.test.mjs
@@ -1,0 +1,93 @@
+// Unit tests for resolveVanishedTask (src/sync/vanishedTaskAction.ts).
+//
+// Run with `npm test`.
+//
+// Getting this wrong is expensive in both directions: too eager and a task that
+// was merely completed in Todoist gets flagged as a problem and has its sync
+// switched off; too lax and a genuinely deleted task keeps being pushed to.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveVanishedTask } from '../.build/sync/vanishedTaskAction.mjs';
+
+const GRACE = 60_000;
+
+/** Old enough that the creation grace window does not apply. */
+const settled = (overrides) => ({
+	mappingAgeMs: 10 * 60_000,
+	creationGraceMs: GRACE,
+	vaultCompleted: false,
+	...overrides,
+});
+
+test('completed in Todoist ticks the vault line', () => {
+	assert.equal(resolveVanishedTask(settled({ completionState: 'completed' })), 'complete-in-vault');
+});
+
+test('completed in Todoist and already ticked just settles', () => {
+	assert.equal(
+		resolveVanishedTask(settled({ completionState: 'completed', vaultCompleted: true })),
+		'settle'
+	);
+});
+
+test('deleted in Todoist is flagged only while the vault line is open', () => {
+	assert.equal(resolveVanishedTask(settled({ completionState: 'missing' })), 'flag-missing');
+	assert.equal(
+		resolveVanishedTask(settled({ completionState: 'missing', vaultCompleted: true })),
+		'settle'
+	);
+});
+
+test('an open task in Todoist means the absence was transient', () => {
+	assert.equal(resolveVanishedTask(settled({ completionState: 'active' })), 'wait');
+});
+
+test('a failed lookup never disables a task', () => {
+	assert.equal(resolveVanishedTask(settled({ completionState: 'unknown' })), 'wait');
+	assert.equal(
+		resolveVanishedTask(settled({ completionState: 'unknown', vaultCompleted: true })),
+		'wait'
+	);
+});
+
+test('nothing is concluded inside the creation grace window', () => {
+	for (const completionState of ['completed', 'missing', 'active', 'unknown']) {
+		assert.equal(
+			resolveVanishedTask({
+				completionState,
+				vaultCompleted: false,
+				mappingAgeMs: 1_000,
+				creationGraceMs: GRACE,
+			}),
+			'wait',
+			`state ${completionState} inside grace window`
+		);
+	}
+});
+
+test('the grace window is exclusive at its boundary', () => {
+	const at = (mappingAgeMs) =>
+		resolveVanishedTask({
+			completionState: 'missing',
+			vaultCompleted: false,
+			mappingAgeMs,
+			creationGraceMs: GRACE,
+		});
+	assert.equal(at(GRACE - 1), 'wait');
+	assert.equal(at(GRACE), 'flag-missing');
+});
+
+test('an unstamped mapping is treated as old enough to judge', () => {
+	// Entries written before createdAt existed have no age; they are all long-lived.
+	assert.equal(
+		resolveVanishedTask({
+			completionState: 'completed',
+			vaultCompleted: false,
+			mappingAgeMs: undefined,
+			creationGraceMs: GRACE,
+		}),
+		'complete-in-vault'
+	);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "isolatedModules": true,
-	"strictNullChecks": true,
+    "strictNullChecks": true,
     "lib": [
       "DOM",
       "ES5",


### PR DESCRIPTION
Supersedes #112, fixes #111.

#112 got syncing working again by moving to `@doist/todoist-sdk`. This keeps that port and fixes the sync bugs that remained on top of it.

### What was broken

- **Tasks disabled themselves.** A task created from Obsidian had its sync switched off as soon as it was edited in Todoist — often just moving the cursor over the line was enough. Conflict detection treated any Todoist revision change as a conflict, before comparing a single field.
- **Ticking a task off in Todoist didn't reach the vault**, and usually got it reported as "no longer exists in Todoist" instead. Completed tasks drop out of `/api/v1/sync` entirely, so completed and deleted were indistinguishable.
- **Brand-new tasks could be deleted from Todoist.** Pressing Backspace a second after adding a task deleted it: the plugin read the file from disk, where the new `todoist_id` had not been saved yet. The same stale read also created duplicate tasks, and `vault.modify()` writes could be overwritten by Obsidian's next autosave.
- **Sync could hang permanently.** `incrementalSync()` never resolved callers that joined a run already in flight, leaving the sync lock held and every later sync failing on a 10s timeout.

### New

Todoist → Obsidian can be turned on again. It has a scope setting that defaults to **Completion only**: a task ticked off in Todoist gets ticked off in your vault, and nothing else on the line is touched. "Everything" keeps the old behaviour, which does rewrite task text.

### Notes

`npm test` runs 16 unit tests (new), and `npm run build` now type-checks — the old dependency shipped typings TypeScript could not parse, which silently disabled type-checking altogether.

Two gaps left deliberately: un-ticking a task that was settled as completed does not reopen it in Todoist, and SDK mutations bypass the plugin's own rate-limit accounting. Per-fix reasoning is in the commit messages.

### To test this build

1. Download the attached zip 
[ultimate-todoist-sync-issue111-fix.zip](https://github.com/user-attachments/files/30373415/ultimate-todoist-sync-issue111-fix.zip)


2. Copy `main.js`, `manifest.json` and `styles.css` into your vault's `.obsidian/plugins/ultimate-todoist-sync/` folder, replacing the existing files
3. Reload Obsidian (Settings → Community plugins → disable, then re-enable *Ultimate Todoist Sync*)

If tasks in your vault already got disabled, clear them under Manage Problem Tasks — entries with sync switched off stay skipped regardless of these fixes.